### PR TITLE
Add Internxt-CLI-WebDAV plugin URL

### DIFF
--- a/plugins/Internxt-CLI-WebDAV.plg
+++ b/plugins/Internxt-CLI-WebDAV.plg
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/syprix/unraid-internxt-cli/main/internxt-cli.xml


### PR DESCRIPTION
Hello, I've created a stable and fully functional template for the Internxt CLI WebDAV server. It solves issues with existing templates by using bridge mode and a robust, diagnostic startup script. The Docker image is built automatically via GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a remote URL reference for the Internxt-CLI-WebDAV plugin definition to fetch its metadata from the specified source.
  * No changes to functionality, error handling, or control flow were introduced.
  * No updates to user interface or settings.
  * No impact on existing configurations or workflows expected.
  * This update focuses solely on sourcing the plugin definition from the noted location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->