### PR TITLE
refactor(css): update Community Applications styles to use CSS Layers and Scope for better isolation

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -1,7 +1,11 @@
 /* ==========================================================================
   Base Styles & Reset
   ========================================================================== */
-body {
+@layer default{
+	@scope (:root) to (.unapi) {
+		
+
+  body {
   scrollbar-gutter: stable;
   cursor: default !important;
 }
@@ -2525,4 +2529,6 @@ img.mfp-img {
   color: var(--unraid-66-color);
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
   transform: translate(-50%, -50%) scale(1.0);
+}
+	}
 }


### PR DESCRIPTION
# Please Note
These changes may not be ready to be merged yet. Please coordinate with the API team @elibosley and webgui team @zackspear.

## Related PRs
**webgui:**
    - [PR (#2504)](https://github.com/unraid/webgui/pull/2504)
    
**api:**
    - [PR (#1860)](https://github.com/unraid/api/pull/1860)    

# Summary
Wraps the entire CA css stylesheet in a `@layer default` and `@scope (:root) to (.unapi)` block. This ensures the styles are at the same specificity level as the webgui's `default-base.css`, correctly isolated, and prevents them from bleeding into or being affected by the global scope outside of the intended hierarchy.

# Reasoning

These changes were primarily made to prevent the small style/css regressions in CA that would arise as a result of the [following PR](https://github.com/unraid/webgui/pull/2504) (pending approval) in the webgui. 

For some context, styles in the newer UI in the Unraid API monorepo are conflicting with the legacy css styles in the webgui. As a result of that, we tried to create a layer of separation between the webgui and the api and also scope the css in the webgui.

Naturally, those styling changes will change the css specificity of CA as well. Although, for the most part, even without these changes, CA's styles did not seem to change. 

However, there were certain styles that were regressing (that I noticed). Primarily, the menu links and the navigation arrows turned blue (they should be white and red respectively). These specificity changes put the CA styles on the same specificity level as the `default-base.css`, which is what it was before. As such, it solves those regressions. 

# Resources
You can read more about [@scope](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope) and [@layer](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer) in the MDN docs. 

# Screenshot of the Problem
If the [webgui PR](https://github.com/unraid/webgui/pull/2504) is accepted, without these stylesheet changes, CA would look something like this:

<img width="2924" height="1310" alt="image" src="https://github.com/user-attachments/assets/d2384ed5-5834-43eb-8ec1-9c5bc00650f9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CSS styling organization to improve how styles are applied and managed across the community applications interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->