### PR TITLE
Add m4brew Community Applications template

### DIFF
--- a/templates/m4brew.xml
+++ b/templates/m4brew.xml
@@ -44,7 +44,7 @@
           Mode="rw" Description="App config folder" Type="Path" Display="always" Required="true" Mask="false"/>
 
   <Config Name="Docker Socket" Target="/var/run/docker.sock" Default="/var/run/docker.sock"
-          Mode="rw" Description="Required to launch helper containers" Type="Path" Display="always" Required="true" Mask="false"/>
+          Mode="rw" Description="Required to launch helper containers. WARNING: Grants container access to Docker daemon." Type="Path" Display="always" Required="true" Mask="false"/>
 
   <!-- Optional audiobook roots (generic + portable) -->
   <Config Name="Audiobooks 1" Target="/audiobooks1" Default=""

--- a/templates/m4brew.xml
+++ b/templates/m4brew.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>m4brew</Name>
+  <Repository>matxby/m4brew:latest</Repository>
+
+  <!-- CA-safe default: don't assume a custom network exists -->
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>bash</Shell>
+  <Privileged>false</Privileged>
+
+  <Support>https://github.com/MATXBY/m4brew</Support>
+  <Project>https://github.com/MATXBY/m4brew</Project>
+  <Overview>m4brew - Audiobook source manager and M4B converter.</Overview>
+  <Category>MediaApp:Audio</Category>
+
+  <WebUI>http://[IP]:[PORT:8080]/</WebUI>
+  <Icon>https://raw.githubusercontent.com/MATXBY/m4brew/master/app/static/images/m4brew-logo.png</Icon>
+
+  <Registry>https://hub.docker.com/r/matxby/m4brew</Registry>
+  <ReadMe>https://github.com/MATXBY/m4brew</ReadMe>
+  <Changes>https://github.com/MATXBY/m4brew/releases</Changes>
+
+  <!-- WebUI port -->
+  <Config Name="WebUI Port" Target="8080" Default="8585" Mode="tcp"
+          Description="Host port for the web UI" Type="Port" Display="always" Required="true" Mask="false"/>
+
+  <!-- Common variables (CA-friendly defaults) -->
+  <Config Name="Timezone" Target="TZ" Default="UTC" Mode=""
+          Description="Timezone (e.g. Europe/London)" Type="Variable" Display="always" Required="true" Mask="false"/>
+
+  <Config Name="PUID" Target="PUID" Default="99" Mode=""
+          Description="User ID (Unraid default: 99)" Type="Variable" Display="always" Required="true" Mask="false"/>
+
+  <Config Name="PGID" Target="PGID" Default="100" Mode=""
+          Description="Group ID (Unraid default: 100)" Type="Variable" Display="always" Required="true" Mask="false"/>
+
+  <Config Name="Docker Network (for helper containers)" Target="DOCKER_NETWORK" Default="bridge" Mode=""
+          Description="Network name used by m4brew when it launches helper containers (usually bridge)"
+          Type="Variable" Display="advanced" Required="false" Mask="false"/>
+
+  <!-- Required paths -->
+  <Config Name="Appdata Config" Target="/config" Default="/mnt/user/appdata/m4brew"
+          Mode="rw" Description="App config folder" Type="Path" Display="always" Required="true" Mask="false"/>
+
+  <Config Name="Docker Socket" Target="/var/run/docker.sock" Default="/var/run/docker.sock"
+          Mode="rw" Description="Required to launch helper containers" Type="Path" Display="always" Required="true" Mask="false"/>
+
+  <!-- Optional audiobook roots (generic + portable) -->
+  <Config Name="Audiobooks 1" Target="/audiobooks1" Default=""
+          Mode="rw,slave" Description="Mapped folder #1 (set host path). Will appear in the UI dropdown." Type="Path" Display="always" Required="false" Mask="false"/>
+
+  <Config Name="Audiobooks 2" Target="/audiobooks2" Default=""
+          Mode="rw,slave" Description="Mapped folder #2 (set host path). Will appear in the UI dropdown." Type="Path" Display="always" Required="false" Mask="false"/>
+
+  <Config Name="Audiobooks 3" Target="/audiobooks3" Default=""
+          Mode="rw,slave" Description="Mapped folder #3 (set host path). Will appear in the UI dropdown." Type="Path" Display="always" Required="false" Mask="false"/>
+</Container>

--- a/templates/m4brew.xml
+++ b/templates/m4brew.xml
@@ -9,7 +9,9 @@
   <Shell>bash</Shell>
   <Privileged>false</Privileged>
 
-  <Support>https://github.com/MATXBY/m4brew</Support>
+  <!-- Support thread on Unraid forums -->
+  <Support>https://forums.unraid.net/topic/197414-support-m4brew-audiobook-source-manager-m4b-converter/</Support>
+
   <Project>https://github.com/MATXBY/m4brew</Project>
   <Overview>m4brew - Audiobook source manager and M4B converter.</Overview>
   <Category>MediaApp:Audio</Category>


### PR DESCRIPTION
This PR adds the Community Applications template for m4brew.

Docker image: https://hub.docker.com/r/matxby/m4brew
Source / README: https://github.com/MATXBY/m4brew
Supports up to 3 mapped audiobook root folders selectable in the UI (more can be added)

First submission for m4brew.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added m4brew application support with a pre-configured container template: web UI exposed (host 8585 → app 8080), default timezone UTC, configurable PUID/PGID, default Docker network, required appdata and Docker socket mounts, and optional audiobook host-path mappings.

* **Documentation**
  * Descriptive, UI-friendly configuration entries and labels for each runtime option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->