### PR TITLE
Update skin.php - fix typo in "class"

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -1632,7 +1632,7 @@ function displayPopup($template) {
     }
   }
   if ( $Plugin && ! isset($installedVersion) ) {
-    $card .= "<tr><td calss='popupTableLeft'>".tr("Current Version")."</td><td class='popupTableRight'>$pluginVersion</td></tr>";
+    $card .= "<tr><td class='popupTableLeft'>".tr("Current Version")."</td><td class='popupTableRight'>$pluginVersion</td></tr>";
   }
 
   if ( $Plugin || ! ($Compatible??null)) {


### PR DESCRIPTION
There is a typo in the name of "class" attribute: "calss". Fixed.
See: line 1635 in  [source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php](url)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an HTML attribute error in the plugin information panel that affected the display of the "Current Version" row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->