### PR TITLE
test: lightweight PHP unit-test harness for CA helpers

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,57 @@
+# Community Applications — Unit Tests
+
+Lightweight PHP test suites for CA. Lives **outside** `source/community.applications/`,
+so `pkg_build.sh` never packages anything in this directory — these files exist only
+for local development and CI, never for distribution.
+
+## Layout
+
+| File | What it covers |
+|---|---|
+| `lib.php` | Tiny assertion framework (`ok()`, `eq()`, `suite_done()`). No PHPUnit, no composer. |
+| `test_url_validation.php` | `validURL()`, `caIsPrivateOrLoopbackHost()`, `caIsPublicHttpUrl()` — the URL-gating surface used by template render sites and the README/changelog sanitizers |
+| `test_strip_image_tag.php` | `PreviousAppsHelpers::stripImageTag()` — colon-after-last-slash docker tag stripping, registry-port preserved |
+| `test_sanitizer.php` | End-to-end markdown render pipeline for README/changelog: raw HTML stripped, anchor/img rebuilt with positive attr whitelist, title-injection attempts sealed |
+| `run.sh` | Orchestrator. SSH's to the server and runs every `test_*.php`. |
+
+## Running
+
+The tests live on the Mac at `/Volumes/GitHub/community.applications/tests/` but
+need to execute on the Unraid server because they `require_once` live plugin
+files (`/usr/local/emhttp/plugins/community.applications/include/...`) and the
+markdown library bundled with Dynamix (`/usr/local/emhttp/plugins/dynamix/include/MarkdownExtra.inc.php`).
+
+```sh
+./run.sh
+```
+
+Override the host with `CA_TEST_HOST=root@another.host ./run.sh`.
+
+Each suite prints `✓` / `✗` per assertion and a tail summary, then exits 0 (all
+passed) or 1 (at least one failed). `run.sh` aggregates the suite exit codes
+and reports overall pass/fail at the bottom.
+
+## Adding a test
+
+1. Create `test_<topic>.php` next to the others.
+2. Top of file:
+   ```php
+   require_once __DIR__ . "/lib.php";
+   require_once "/usr/local/emhttp/plugins/community.applications/include/<file>.php";
+   ```
+3. Use `ok("name", $bool, "optional detail")` or `eq("name", $expected, $actual)`.
+4. End with `suite_done();`.
+5. Re-run `./run.sh` — the orchestrator picks up `test_*.php` automatically.
+
+## Conventions
+
+- **Pure functions only.** If a function depends on `$GLOBALS`, the appfeed,
+  filesystem state, or an MCP, the test should mock the input or set up a
+  minimal fixture, not call live endpoints.
+- **No network.** No real DNS lookups, no actual HTTP fetches. The pipeline
+  tests pass synthetic markdown strings through the sanitizer, not real
+  README URLs.
+- **Use `ReflectionMethod` for private statics** (see `test_strip_image_tag.php`).
+- **DOM-verify attribute injection.** Substring matches can give false
+  positives — `test_sanitizer.php` parses the output through `DOMDocument` for
+  the title-injection cases.

--- a/tests/lib.php
+++ b/tests/lib.php
@@ -1,0 +1,106 @@
+<?php
+/* Tiny assertion framework so tests don't need PHPUnit / composer.
+   Each test file:
+     require_once __DIR__ . "/lib.php";
+     ok("name", $cond, "optional detail on fail");
+     eq("name", $expected, $actual);
+     ...
+     suite_done();   // prints summary, exits 0/1
+
+   Translation stubs: define _() and tr() BEFORE the test file pulls in
+   helpers.php, so functions that call tr() (e.g. PopulateAutoCompleteHelpers::
+   buildBaseSuggestions) don't crash on the missing gettext bootstrap.
+   helpers.php's own tr() is wrapped in `if (!function_exists("tr"))` so our
+   stub is what wins. _() returns the input string verbatim so tr() ends up
+   returning the input string verbatim too — fine for test assertions, since
+   we're testing logic not translation. */
+
+if (!function_exists("_")) {
+	function _($string, $options = -1) { return $string; }
+}
+if (!function_exists("tr")) {
+	function tr($string, $options = -1) { return $string; }
+}
+
+/* Populate $GLOBALS the way the live request bootstrap does, so any function
+   under test that reads $GLOBALS['templates'] / ['caSettings'] / ['sortOrder']
+   has something sensible to work against.
+
+   - $GLOBALS['templates'] uses the same source getGlobals() does:
+     CA_PATHS['community-templates-info'] (i.e. /tmp/community.applications/
+     tempFiles/templates_new.json) read via readJsonFile() so format detection
+     (serialize vs JSON) matches production. If the file isn't present (e.g.
+     running on a host without CA installed), $GLOBALS['templates'] stays []
+     instead of crashing.
+
+   - $GLOBALS['caSettings'] is a permissive default stub. Tests that exercise
+     specific settings should override the keys they care about BEFORE calling
+     the function under test. Mirrors what getSettings() would have set.
+
+   - $GLOBALS['action'] is the request action label that debug() prepends to
+     log lines; lib gives it 'unit_test' so debug spam is identifiable.
+
+   - $GLOBALS['sortOrder'] is read by mySort(); given a default so sort tests
+     don't crash before they configure it.
+
+   Call ca_test_load_fixtures() AFTER your test has required paths.php and
+   helpers.php — those need to be loaded first so CA_PATHS and readJsonFile()
+   exist. */
+function ca_test_load_fixtures(): void {
+	$GLOBALS['action']    = $GLOBALS['action']    ?? "unit_test";
+	$GLOBALS['sortOrder'] = $GLOBALS['sortOrder'] ?? ["sortBy" => "Name", "sortDir" => "Up"];
+
+	$GLOBALS['caSettings'] = $GLOBALS['caSettings'] ?? [
+		"dockerSearch"     => "yes",
+		"unRaidVersion"    => "7.0.0",
+		"favourite"        => "",
+		"dynamixTheme"     => "black",
+		"NoInstalls"       => false,
+		"hideIncompatible" => "true",
+		"hideDeprecated"   => "true",
+		"dev"              => "no",
+	];
+
+	if (!isset($GLOBALS['templates'])) {
+		$GLOBALS['templates'] = [];
+		if (defined("CA_PATHS") && function_exists("readJsonFile")) {
+			$path = CA_PATHS['community-templates-info'] ?? "";
+			if ($path !== "" && is_file($path)) {
+				$loaded = readJsonFile($path);
+				if (is_array($loaded)) $GLOBALS['templates'] = $loaded;
+			}
+		}
+	}
+}
+
+class CATest {
+	public static int $passed = 0;
+	public static int $failed = 0;
+	public static array $failures = [];
+
+	public static function ok(string $name, bool $cond, string $detail = "") {
+		if ($cond) {
+			self::$passed++;
+			echo "  ✓ {$name}\n";
+		} else {
+			self::$failed++;
+			self::$failures[] = $detail === "" ? $name : "{$name} — {$detail}";
+			echo "  ✗ {$name}" . ($detail === "" ? "" : " — {$detail}") . "\n";
+		}
+	}
+
+	public static function eq(string $name, $expected, $actual) {
+		$cond = ($expected === $actual);
+		$detail = $cond ? "" : "expected " . var_export($expected, true) . ", got " . var_export($actual, true);
+		self::ok($name, $cond, $detail);
+	}
+
+	public static function summary(): int {
+		echo "\nPassed: " . self::$passed . "    Failed: " . self::$failed . "\n";
+		return self::$failed > 0 ? 1 : 0;
+	}
+}
+
+function ok(string $n, bool $c, string $d = ""): void   { CATest::ok($n, $c, $d); }
+function eq(string $n, $e, $a): void                    { CATest::eq($n, $e, $a); }
+function suite_done(): void                              { exit(CATest::summary()); }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -12,25 +12,28 @@ set -u
 REMOTE_HOST="${CA_TEST_HOST:-root@unraida-1.tail4a32cc.ts.net}"
 REMOTE_TESTS_DIR="/mnt/user/GitHub/community.applications/tests"
 
-ssh -o BatchMode=yes "$REMOTE_HOST" bash -s <<EOF
+# Quoted heredoc (<<'EOF') so $variables aren't expanded client-side; we pass
+# REMOTE_TESTS_DIR explicitly via the ssh command env so the remote shell uses
+# its own value with no escaping required inside the script body.
+ssh -o BatchMode=yes "$REMOTE_HOST" REMOTE_TESTS_DIR="$REMOTE_TESTS_DIR" bash -s <<'EOF'
 set -u
 overall=0
 for t in "$REMOTE_TESTS_DIR"/test_*.php; do
   echo
   echo "════════════════════════════════════════════════════════"
-  echo "  \$(basename "\$t")"
+  echo "  $(basename "$t")"
   echo "════════════════════════════════════════════════════════"
-  if ! php "\$t"; then
+  if ! php "$t"; then
     overall=1
   fi
 done
 echo
 echo "════════════════════════════════════════════════════════"
-if [ \$overall -eq 0 ]; then
+if [ $overall -eq 0 ]; then
   echo "  ALL SUITES PASSED"
 else
   echo "  ONE OR MORE SUITES FAILED"
 fi
 echo "════════════════════════════════════════════════════════"
-exit \$overall
+exit $overall
 EOF

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run all CA unit tests on the Unraid server.
+# Tests live at /Volumes/GitHub/community.applications/tests/ on the Mac, which
+# maps to /mnt/user/GitHub/community.applications/tests/ on the server.
+# This dir is OUTSIDE source/community.applications/ so pkg_build.sh never
+# packages them — they exist only for local CI.
+#
+# Usage: ./run.sh
+#        Exits 0 if every suite passes, 1 if any suite has failures.
+set -u
+
+REMOTE_HOST="${CA_TEST_HOST:-root@unraida-1.tail4a32cc.ts.net}"
+REMOTE_TESTS_DIR="/mnt/user/GitHub/community.applications/tests"
+
+ssh -o BatchMode=yes "$REMOTE_HOST" bash -s <<EOF
+set -u
+overall=0
+for t in "$REMOTE_TESTS_DIR"/test_*.php; do
+  echo
+  echo "════════════════════════════════════════════════════════"
+  echo "  \$(basename "\$t")"
+  echo "════════════════════════════════════════════════════════"
+  if ! php "\$t"; then
+    overall=1
+  fi
+done
+echo
+echo "════════════════════════════════════════════════════════"
+if [ \$overall -eq 0 ]; then
+  echo "  ALL SUITES PASSED"
+else
+  echo "  ONE OR MORE SUITES FAILED"
+fi
+echo "════════════════════════════════════════════════════════"
+exit \$overall
+EOF

--- a/tests/test_array_helpers.php
+++ b/tests/test_array_helpers.php
@@ -1,0 +1,109 @@
+<?php
+/* Tests for array/lookup utilities in include/helpers.php:
+   searchArray, duplicateArrayWithoutKeys, filterMatch */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+echo "=== searchArray ===\n";
+
+$templates = [
+	["Repository" => "linuxserver/plex",        "Name" => "Plex"],
+	["Repository" => "linuxserver/sonarr",      "Name" => "Sonarr"],
+	["Repository" => "linuxserver/radarr",      "Name" => "Radarr"],
+	["Repository" => "ghcr.io/owner/foo:latest","Name" => "Foo"],
+];
+
+eq("finds first match",          0, searchArray($templates, "Repository", "linuxserver/plex"));
+eq("finds middle match",         1, searchArray($templates, "Repository", "linuxserver/sonarr"));
+eq("finds last match",           3, searchArray($templates, "Repository", "ghcr.io/owner/foo:latest"));
+ok("missing returns false",      searchArray($templates, "Repository", "no/such") === false);
+ok("missing key returns false",  searchArray($templates, "DoesNotExist", "x") === false);
+ok("empty array returns false",  searchArray([], "Repository", "x") === false);
+
+eq("startingIndex skips earlier matches",
+   2,
+   searchArray($templates, "Name", "Radarr", 1));
+
+ok("startingIndex past last match → false",
+   searchArray($templates, "Repository", "linuxserver/plex", 1) === false);
+
+/* Search by Name */
+eq("searches by Name, case sensitive equality",
+   1, searchArray($templates, "Name", "Sonarr"));
+
+echo "\n=== duplicateArrayWithoutKeys ===\n";
+
+/* duplicateArrayWithoutKeys is designed for arrays-of-arrays (e.g. the
+   templates list). Each row must be an array; the function:
+     - drops the specified keys from each row
+     - stamps an "ArrayIndex" key on each row with that row's source index
+     - returns the copy (source is also mutated to add ArrayIndex on each row,
+       per the comment "stamp index on the original")
+*/
+
+$rows = [
+	["Name" => "Plex",   "Repository" => "linuxserver/plex",   "secret" => "drop-me"],
+	["Name" => "Sonarr", "Repository" => "linuxserver/sonarr", "secret" => "drop-me"],
+];
+
+$kept = duplicateArrayWithoutKeys($rows, ["secret"]);
+eq("specified key removed from each row + ArrayIndex stamped",
+   [
+	["Name" => "Plex",   "Repository" => "linuxserver/plex",   "ArrayIndex" => 0],
+	["Name" => "Sonarr", "Repository" => "linuxserver/sonarr", "ArrayIndex" => 1],
+   ],
+   $kept);
+
+// Empty keysToRemove just stamps ArrayIndex (no key removal)
+$rows2 = [["a" => 1], ["b" => 2]];
+$kept2 = duplicateArrayWithoutKeys($rows2);
+eq("no keys to remove → still stamps ArrayIndex",
+   [["a" => 1, "ArrayIndex" => 0], ["b" => 2, "ArrayIndex" => 1]],
+   $kept2);
+
+// Scalar entries pass through as-is (no ArrayIndex stamp on non-array rows)
+$mixed = ["a" => 1, "b" => ["x" => "keep", "secret" => "drop"]];
+$kept3 = duplicateArrayWithoutKeys($mixed, ["secret"]);
+eq("scalar rows pass through; array rows are filtered + stamped",
+   [
+	"a" => 1,
+	"b" => ["x" => "keep", "ArrayIndex" => "b"],
+   ],
+   $kept3);
+
+// Removing an absent key from each row is a no-op (ArrayIndex still stamped)
+$rows4 = [["x" => 1]];
+$kept4 = duplicateArrayWithoutKeys($rows4, ["nope"]);
+eq("removing absent key still stamps ArrayIndex",
+   [["x" => 1, "ArrayIndex" => 0]],
+   $kept4);
+
+echo "\n=== filterMatch ===\n";
+
+/* filterMatch($filter, $searchArray, $exact=true) — used in template search.
+   Each entry in $searchArray is a candidate string to match against $filter.
+   Behavior:
+     - exact=true (default): every space-separated word in $filter must appear
+       (substring) in at least one candidate.
+     - exact=false: same loose word-by-word substring match. */
+
+ok("single word matches one of the candidates",
+   (bool)filterMatch("plex", ["Plex Media Server", "linuxserver/plex"]));
+
+ok("word missing from all candidates",
+   !filterMatch("zzzzz", ["Plex Media Server", "linuxserver/plex"]));
+
+ok("multi-word filter where every word appears (in any candidate)",
+   (bool)filterMatch("plex media", ["Plex Media Server", "linuxserver/plex"]));
+
+ok("multi-word filter, one word absent → no match",
+   !filterMatch("plex spotify", ["Plex Media Server", "linuxserver/plex"]));
+
+ok("empty candidate list → no match",
+   !filterMatch("anything", []));
+
+ok("mixed case filter against mixed case candidate (case-insensitive)",
+   (bool)filterMatch("PLEX", ["Plex Media Server"]));
+
+suite_done();

--- a/tests/test_autocomplete.php
+++ b/tests/test_autocomplete.php
@@ -1,0 +1,82 @@
+<?php
+/* Tests for the PopulateAutoCompleteHelpers class — search-suggestion builder.
+   Recently fixed: stripPrefix used to use str_replace (stripping every
+   occurrence of the prefix), now uses substr only when the prefix is at
+   position 0. addNameSuggestion now stores stripped aliases as separate
+   keys instead of overwriting one entry. */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";  // for startsWith()
+require_once "/usr/local/emhttp/plugins/community.applications/include/populate_autocomplete_helpers.php";
+
+echo "=== PopulateAutoCompleteHelpers::stripPrefix (private static) ===\n";
+
+$ref = new ReflectionMethod("PopulateAutoCompleteHelpers", "stripPrefix");
+$ref->setAccessible(true);
+$strip = function (string $value, string $prefix) use ($ref) {
+	return $ref->invoke(null, $value, $prefix);
+};
+
+// Prefix at start → stripped
+eq("strips leading prefix",         "plex",          $strip("docker-plex", "docker-"));
+eq("strips multi-segment prefix",   "name",          $strip("library/name", "library/"));
+
+// Prefix not at start → no change (older bug: would str_replace and remove from middle)
+eq("prefix in middle untouched",    "abc-docker-xyz", $strip("abc-docker-xyz", "docker-"));
+eq("multiple occurrences only first stripped",
+   "docker-plex-docker", $strip("docker-docker-plex-docker", "docker-"));
+
+// Edge cases
+eq("empty value → empty",           "",              $strip("", "docker-"));
+eq("empty prefix → unchanged",      "anything",      $strip("anything", ""));
+eq("prefix exactly equals value → empty result",
+   "",              $strip("docker-", "docker-"));
+eq("value shorter than prefix → unchanged",
+   "abc",           $strip("abc", "docker-very-long-prefix-"));
+
+echo "\n=== PopulateAutoCompleteHelpers::buildBaseSuggestions ===\n";
+
+/* buildBaseSuggestions reads CA_PATHS['categoryList'] via readJsonFile and
+   feeds the results through tr(). lib.php stubs tr() to return its input,
+   so this exercises the array-shaping path without needing a real
+   translation bootstrap. */
+
+$_POST = [];
+require_once "/usr/local/emhttp/plugins/community.applications/include/paths.php";
+
+$out = PopulateAutoCompleteHelpers::buildBaseSuggestions();
+ok("buildBaseSuggestions returns array",       is_array($out));
+ok("returns at least one category",            count($out) > 0);
+ok("entries are strings",                       array_reduce($out, function ($carry, $v) { return $carry && is_string($v); }, true));
+ok("contains some recognizable categories from the live categoryList file",
+   /* Loose check: live CA_PATHS['categoryList'] should expose at least a few of these */
+   (bool)array_intersect($out, ["AI", "Backup", "Cloud", "MediaServer", "Network", "Tools", "Other"]),
+   var_export($out, true));
+
+echo "\n=== addRepositorySuggestion (private static) — RepoName key handling ===\n";
+
+$ref2 = new ReflectionMethod("PopulateAutoCompleteHelpers", "addRepositorySuggestion");
+$ref2->setAccessible(true);
+$addRepo = function ($template, $autoComplete) use ($ref2) {
+	return $ref2->invoke(null, $template, $autoComplete);
+};
+
+// Template with Repo set, not a language pack → suggestion added
+$result = $addRepo(["Repo" => "linuxserver"], []);
+ok("Repo present, non-language → suggestion added",
+   !empty($result) && in_array("linuxserver", $result, true),
+   var_export($result, true));
+
+// Language pack templates are excluded
+$result = $addRepo(["Repo" => "linuxserver", "Language" => "fr_FR", "LanguageLocal" => "Français"], []);
+eq("language template → no suggestion",
+   [],
+   $result);
+
+// Missing Repo → no suggestion
+$result = $addRepo(["Name" => "Plex"], []);
+eq("missing Repo → no suggestion",
+   [],
+   $result);
+
+suite_done();

--- a/tests/test_fix_description.php
+++ b/tests/test_fix_description.php
@@ -1,0 +1,78 @@
+<?php
+/* Tests for fixDescription() — converts the legacy [tag] markup that lives in
+   template Description fields into safe HTML. Recently de-greedied to stop
+   <span>...<span>... patterns from collapsing across the whole description. */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+echo "=== fixDescription ===\n";
+
+// Non-string input
+eq("null input → empty string",   "", fixDescription(null));
+eq("array input → empty string",  "", fixDescription(["x"]));
+eq("integer input → empty string","", fixDescription(123));
+
+// Plain text passes through trimmed
+eq("plain text trimmed",          "hello world", fixDescription("  hello world  "));
+
+// [br] / [BR] become <br>, then strip_tags keeps the actual <br>... wait,
+// strip_tags WITHOUT a whitelist removes <br> too. So the final output has
+// the <br>'s removed. Document this: fixDescription is meant to extract the
+// *text* of a description, not preserve formatting tags.
+$out = fixDescription("Line one[br]Line two");
+ok("[br] handled (does not leave literal '[br]')",  strpos($out, "[br]") === false, $out);
+
+// [b] / [/b] — the regex maps [b] specifically, but strip_tags removes the
+// resulting <b> too. Just verify the bracket form doesn't leak through as text.
+$out = fixDescription("This is [b]important[/b] really");
+ok("[b]/[/b] handled",  strpos($out, "[b]") === false && strpos($out, "[/b]") === false, $out);
+
+// Generic [tag] becomes <tag> then gets strip_tagged out.
+$out = fixDescription("Click [a href=https://example.com]here[/a] for info");
+ok("inline anchor brackets removed entirely (text remains)",
+   strpos($out, "here") !== false && strpos($out, "[a") === false && strpos($out, "<a") === false,
+   $out);
+
+// Span tags removed
+$out = fixDescription("Some <span class='foo'>highlighted</span> text");
+eq("span tags scrubbed, text remains",
+   "Some highlighted text",
+   $out);
+
+// The de-greedying fix: multiple <span>...<span> shouldn't collapse the entire
+// description into nothing.
+$out = fixDescription("First <span>A</span> middle <span>B</span> end");
+ok("multiple span pairs each scrubbed independently (de-greedied)",
+   strpos($out, "First")  !== false &&
+   strpos($out, "middle") !== false &&
+   strpos($out, "end")    !== false &&
+   strpos($out, "<span")  === false &&
+   strpos($out, "</span>") === false,
+   $out);
+
+// HTML entity decoding in the bracket-form
+$out = fixDescription("a &lt;b&gt; c");
+ok("&lt;/&gt; entities normalize to literal text and get scrubbed",
+   /* strtr converts to <,> then strip_tags strips the resulting tag */
+   strpos($out, "a") !== false && strpos($out, "c") !== false,
+   $out);
+
+// Pure raw HTML: tags get stripped but the function does NOT remove the
+// content between tags (it's a tag scrubber, not a sanitizer; the README/
+// changelog pipeline is the place that strips content between tags). The
+// description ends up as plain text — safe because there are no tags left.
+$out = fixDescription("<script>alert(1)</script>after");
+ok("raw <script> tags removed (content remains as plain text — no tags survive)",
+   strpos($out, "<script") === false &&
+   strpos($out, "</script>") === false &&
+   strpos($out, "after") !== false,
+   $out);
+
+// Empty string
+eq("empty string → empty string",  "", fixDescription(""));
+
+// Whitespace-only
+eq("whitespace-only → empty",      "", fixDescription("   \t\n  "));
+
+suite_done();

--- a/tests/test_format_helpers.php
+++ b/tests/test_format_helpers.php
@@ -1,0 +1,119 @@
+<?php
+/* Tests for the small formatting helpers in include/helpers.php:
+   getDownloads, languageAuthorList, categoryList, plain, var_dump_ret,
+   arrayEntriesToObject.
+
+   These don't need the full $GLOBALS fixture; tr() is stubbed in lib.php to
+   return its input verbatim, which is enough for assertions. */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+echo "=== getDownloads (rounds to nearest declared bracket) ===\n";
+
+ok("15M downloads → 'More than 10,000,000'",
+   strpos(getDownloads(15_000_000), "10,000,000") !== false);
+
+ok("1.5M downloads → 'More than 1,000,000'",
+   strpos(getDownloads(1_500_000), "1,000,000") !== false);
+
+ok("5500 downloads → 'More than 5,000'",
+   strpos(getDownloads(5500), "5,000") !== false);
+
+ok("125 downloads → 'More than 100'",
+   strpos(getDownloads(125), "100") !== false);
+
+eq("low count without flag → empty string",   "",   getDownloads(50));
+eq("low count with lowFlag → returns count",  50,   getDownloads(50, true));
+eq("zero downloads, no flag → empty",         "",   getDownloads(0));
+eq("zero downloads, with flag → 0",           0,    getDownloads(0, true));
+
+echo "\n=== languageAuthorList (3 or fewer kept verbatim, 4+ truncated) ===\n";
+
+eq("single author kept verbatim",
+   "John Doe",
+   languageAuthorList("John Doe"));
+
+eq("three authors kept verbatim (count <= 3)",
+   "Author1, Author2, Author3",
+   languageAuthorList("Author1, Author2, Author3"));
+
+$out = languageAuthorList("A1, A2, A3, A4, A5");
+ok("five authors → first two + 'and 3 more' suffix",
+   strpos($out, "A1") !== false &&
+   strpos($out, "A2") !== false &&
+   strpos($out, "more") !== false &&
+   strpos($out, "A4") === false,
+   $out);
+
+echo "\n=== categoryList (≤ 2 categories shown by default + 'and N more') ===\n";
+
+eq("single category passes through",
+   "Media",
+   categoryList("Media"));
+
+$out = categoryList("Media,Server,Docker,Network");
+ok("4 categories → first 2 + 'and 2 more' suffix (popUp=false)",
+   strpos($out, "Media")  !== false &&
+   strpos($out, "Server") !== false &&
+   strpos($out, "more")   !== false &&
+   strpos($out, "Docker") === false,
+   $out);
+
+$out = categoryList("Media,Server,Docker,Network", true);
+ok("popUp=true shows ALL categories",
+   strpos($out, "Media")   !== false &&
+   strpos($out, "Server")  !== false &&
+   strpos($out, "Docker")  !== false &&
+   strpos($out, "Network") !== false &&
+   strpos($out, "more")    === false,
+   $out);
+
+$out = categoryList("Media:Server: Docker");
+ok("colon/space separator forms normalized to comma",
+   strpos($out, "Media")  !== false &&
+   strpos($out, "Server") !== false,
+   $out);
+
+echo "\n=== plain (strips brackets from IPv6-literal form) ===\n";
+
+eq("IPv6 brackets removed",  "::1",          plain("[::1]"));
+eq("IPv4 unchanged",         "192.168.1.1",  plain("192.168.1.1"));
+eq("bracketed IPv4 unwrapped","192.168.1.1", plain("[192.168.1.1]"));
+eq("empty input",            "",             plain(""));
+
+echo "\n=== var_dump_ret (captures var_dump into a string) ===\n";
+
+ok("dumping array returns a string",  is_string(var_dump_ret(["a", "b"])));
+ok("dumping array string contains element", strpos(var_dump_ret(["foo" => "bar"]), "foo") !== false);
+ok("dumping null returns a string mentioning NULL",
+   strpos(strtoupper(var_dump_ret(null)), "NULL") !== false);
+ok("default arg (no input) returns a string",   is_string(var_dump_ret()));
+
+echo "\n=== arrayEntriesToObject (array_fill_keys helper) ===\n";
+
+eq("flips values to keys with default flag = true",
+   ["foo" => true, "bar" => true, "baz" => true],
+   arrayEntriesToObject(["foo", "bar", "baz"]));
+
+eq("flips with custom default value",
+   ["foo" => false, "bar" => false],
+   arrayEntriesToObject(["foo", "bar"], false));
+
+eq("flips with arbitrary default",
+   ["a" => 42, "b" => 42],
+   arrayEntriesToObject(["a", "b"], 42));
+
+eq("non-array input returns []",
+   [],
+   arrayEntriesToObject("not an array"));
+
+eq("null input returns []",
+   [],
+   arrayEntriesToObject(null));
+
+eq("empty array input returns empty array",
+   [],
+   arrayEntriesToObject([]));
+
+suite_done();

--- a/tests/test_globals_fixture.php
+++ b/tests/test_globals_fixture.php
@@ -1,0 +1,150 @@
+<?php
+/* Tests for the ca_test_load_fixtures() helper itself, plus a sample of
+   functions that depend on $GLOBALS — getAuthor(), mySort(), repositorySort(),
+   favouriteSort() — to confirm the fixture stub gives them a working
+   environment without the live request bootstrap. */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+$_POST = [];
+require_once "/usr/local/emhttp/plugins/community.applications/include/paths.php";
+
+ca_test_load_fixtures();
+
+echo "=== Fixture state ===\n";
+
+ok("\$GLOBALS['templates'] is an array",       is_array($GLOBALS['templates']));
+ok("\$GLOBALS['caSettings'] is set",            is_array($GLOBALS['caSettings'] ?? null));
+ok("caSettings has expected default keys",
+   isset($GLOBALS['caSettings']['dockerSearch']) &&
+   isset($GLOBALS['caSettings']['unRaidVersion']) &&
+   isset($GLOBALS['caSettings']['dynamixTheme']));
+ok("\$GLOBALS['sortOrder'] has sortBy + sortDir",
+   isset($GLOBALS['sortOrder']['sortBy']) &&
+   isset($GLOBALS['sortOrder']['sortDir']));
+ok("\$GLOBALS['action'] set for debug() output",   ($GLOBALS['action'] ?? "") !== "");
+
+/* Live-data path: if /tmp/community.applications/tempFiles/templates_new.json
+   exists on this host, we expect $GLOBALS['templates'] to be non-empty. */
+$live = CA_PATHS['community-templates-info'] ?? "";
+if ($live !== "" && is_file($live)) {
+	ok("live templates_new.json found → \$GLOBALS['templates'] non-empty",
+	   count($GLOBALS['templates']) > 0,
+	   "live={$live}, count=" . count($GLOBALS['templates']));
+	$first = reset($GLOBALS['templates']);
+	ok("first live template is an array",            is_array($first));
+} else {
+	ok("no live templates_new.json (test host without CA cache) — fixture left templates empty",
+	   $GLOBALS['templates'] === []);
+}
+
+echo "\n=== getAuthor — pure on input, exercises various Repository shapes ===\n";
+
+eq("PluginURL present → uses PluginAuthor",
+   "alex",
+   getAuthor(["PluginURL" => "https://x/foo.plg", "PluginAuthor" => "alex"]));
+
+eq("Author field set → returns stripped Author",
+   "limetech",
+   getAuthor(["Author" => "limetech", "Repository" => "lscr.io/whatever"]));
+
+eq("docker repo: linuxserver/sonarr → 'linuxserver'",
+   "linuxserver",
+   getAuthor(["Repository" => "linuxserver/sonarr"]));
+
+eq("docker repo with tag stripped from author segment",
+   "linuxserver",
+   getAuthor(["Repository" => "linuxserver/sonarr:latest"]));
+
+eq("ghcr.io prefix stripped before extracting author",
+   "owner",
+   getAuthor(["Repository" => "ghcr.io/owner/repo:1.0"]));
+
+eq("lscr.io prefix stripped",
+   "linuxserver",
+   getAuthor(["Repository" => "lscr.io/linuxserver/sonarr"]));
+
+eq("library/ prefix stripped",
+   /* "library/foo" → strip "library/" → "foo" → explode("/") = ["foo"] →
+      count<2 so push "" → ["foo",""] → repoEntry[count-2] = "foo" */
+   "foo",
+   getAuthor(["Repository" => "library/foo"]));
+
+echo "\n=== mySort (uses \$GLOBALS['sortOrder']) ===\n";
+
+$apps = [
+	["SortName" => "Plex",   "downloads" => 1000, "FirstSeen" => 1700000000],
+	["SortName" => "Sonarr", "downloads" => 500,  "FirstSeen" => 1600000000],
+	["SortName" => "Radarr", "downloads" => 750,  "FirstSeen" => 1650000000],
+];
+
+// Sort by Name ascending
+$GLOBALS['sortOrder'] = ["sortBy" => "Name", "sortDir" => "Up"];
+$copy = $apps;
+usort($copy, "mySort");
+eq("sort by Name asc → Plex, Radarr, Sonarr",
+   ["Plex", "Radarr", "Sonarr"],
+   array_column($copy, "SortName"));
+
+// Sort by Name descending
+$GLOBALS['sortOrder'] = ["sortBy" => "Name", "sortDir" => "Down"];
+$copy = $apps;
+usort($copy, "mySort");
+eq("sort by Name desc → Sonarr, Radarr, Plex",
+   ["Sonarr", "Radarr", "Plex"],
+   array_column($copy, "SortName"));
+
+// Sort by downloads descending (numeric)
+$GLOBALS['sortOrder'] = ["sortBy" => "downloads", "sortDir" => "Down"];
+$copy = $apps;
+usort($copy, "mySort");
+eq("sort by downloads desc → 1000, 750, 500",
+   [1000, 750, 500],
+   array_column($copy, "downloads"));
+
+// Sort by FirstSeen ascending
+$GLOBALS['sortOrder'] = ["sortBy" => "FirstSeen", "sortDir" => "Up"];
+$copy = $apps;
+usort($copy, "mySort");
+eq("sort by FirstSeen asc → oldest first",
+   [1600000000, 1650000000, 1700000000],
+   array_column($copy, "FirstSeen"));
+
+echo "\n=== favouriteSort (uses \$GLOBALS['caSettings']['favourite']) ===\n";
+
+$repos = [
+	["Repo" => "linuxserver"],
+	["Repo" => "ich777"],
+	["Repo" => "binhex"],
+];
+
+$GLOBALS['caSettings']['favourite'] = "ich777";
+$copy = $repos;
+usort($copy, "favouriteSort");
+eq("favourite repo bubbles to the top",
+   "ich777",
+   $copy[0]["Repo"]);
+
+$GLOBALS['caSettings']['favourite'] = "no-such-repo";
+$copy = $repos;
+usort($copy, "favouriteSort");
+eq("no matching favourite → array order preserved (stable enough for first item)",
+   "linuxserver",
+   $copy[0]["Repo"]);
+
+echo "\n=== repositorySort (uses \$GLOBALS['caSettings']['favourite']) ===\n";
+
+$repoCards = [
+	["RepoName" => "linuxserver"],
+	["RepoName" => "ich777"],
+	["RepoName" => "binhex"],
+];
+
+$GLOBALS['caSettings']['favourite'] = "binhex";
+$copy = $repoCards;
+usort($copy, "repositorySort");
+eq("favourite repo card surfaces first",
+   "binhex",
+   $copy[0]["RepoName"]);
+
+suite_done();

--- a/tests/test_json_io.php
+++ b/tests/test_json_io.php
@@ -1,0 +1,93 @@
+<?php
+/* Tests for readJsonFile() / ca_file_put_contents() — the on-disk persistence
+   helpers used throughout the plugin (cache files, settings, etc.). Uses
+   tempnam() so the tests don't touch any real CA paths.
+
+   readJsonFile auto-detects format: it tries unserialize() first, falls back
+   to json_decode(). writeJsonFile prefers serialize() when humanReadable is
+   off (the production default).
+
+   We only exercise readJsonFile + ca_file_put_contents directly — writeJsonFile
+   has a side effect of writing a sibling templates.json when the filename
+   matches CA_PATHS['community-templates-info'], which we don't want to
+   trigger in tests. */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+/* readJsonFile() and ca_file_put_contents() both rely on $GLOBALS['action']
+   for debug() — give it a placeholder so debug() doesn't spam stdout. */
+$GLOBALS['action'] = 'unit_test';
+
+echo "=== readJsonFile ===\n";
+
+// Missing file → default
+$missing = "/tmp/__ca_test_does_not_exist_" . uniqid() . ".dat";
+@unlink($missing);
+eq("missing file returns default ([])",       [], readJsonFile($missing));
+eq("missing file returns custom default",     ["x" => 1], readJsonFile($missing, ["x" => 1]));
+
+// Serialized payload (production default)
+$path_ser = tempnam(sys_get_temp_dir(), "ca_ser_");
+file_put_contents($path_ser, serialize(["foo" => 1, "bar" => [2, 3]]));
+eq("reads serialized payload",
+   ["foo" => 1, "bar" => [2, 3]],
+   readJsonFile($path_ser));
+@unlink($path_ser);
+
+// JSON payload (humanReadable mode)
+$path_json = tempnam(sys_get_temp_dir(), "ca_json_");
+file_put_contents($path_json, json_encode(["a" => "b", "c" => [1, 2, 3]]));
+eq("reads JSON payload",
+   ["a" => "b", "c" => [1, 2, 3]],
+   readJsonFile($path_json));
+@unlink($path_json);
+
+// Garbage → default (graceful failure)
+$path_garbage = tempnam(sys_get_temp_dir(), "ca_garbage_");
+file_put_contents($path_garbage, "this is not json or serialized");
+eq("garbage payload returns default",
+   [],
+   readJsonFile($path_garbage));
+eq("garbage payload returns custom default",
+   ["fallback" => true],
+   readJsonFile($path_garbage, ["fallback" => true]));
+@unlink($path_garbage);
+
+// Empty file → default
+$path_empty = tempnam(sys_get_temp_dir(), "ca_empty_");
+file_put_contents($path_empty, "");
+eq("empty file returns default", [], readJsonFile($path_empty));
+@unlink($path_empty);
+
+// JSON null specifically — readJsonFile treats null as "couldn't read", returns default
+$path_null = tempnam(sys_get_temp_dir(), "ca_null_");
+file_put_contents($path_null, "null");
+eq("JSON null returns default ([] in this run)", [], readJsonFile($path_null));
+@unlink($path_null);
+
+echo "\n=== ca_file_put_contents (atomic write via .~ rename) ===\n";
+
+// Round-trip: write serialized then read back via readJsonFile
+$path_rt = tempnam(sys_get_temp_dir(), "ca_rt_");
+$payload = ["roundtrip" => true, "list" => [1, 2, 3], "nested" => ["k" => "v"]];
+ca_file_put_contents($path_rt, serialize($payload));
+eq("write+read serialized round-trip", $payload, readJsonFile($path_rt));
+@unlink($path_rt);
+
+// Round-trip: write JSON
+$path_rt2 = tempnam(sys_get_temp_dir(), "ca_rt2_");
+ca_file_put_contents($path_rt2, json_encode($payload));
+eq("write+read JSON round-trip", $payload, readJsonFile($path_rt2));
+@unlink($path_rt2);
+
+// ca_file_put_contents writes to filename + "~" then renames. Verify the temp
+// is gone after a successful write.
+$path_atomic = tempnam(sys_get_temp_dir(), "ca_atomic_");
+ca_file_put_contents($path_atomic, "hello");
+ok("post-write: temp .~ file is gone",  !is_file($path_atomic . "~"));
+ok("post-write: target file exists",    is_file($path_atomic));
+eq("contents written correctly",        "hello", file_get_contents($path_atomic));
+@unlink($path_atomic);
+
+suite_done();

--- a/tests/test_path_helpers.php
+++ b/tests/test_path_helpers.php
@@ -1,0 +1,103 @@
+<?php
+/* Tests for the per-tab cache path suffixing in include/paths.php.
+   $caTabSuffix is derived from $_POST['tabId'] when present and matching the
+   strict regex; suffixes a small whitelist of cache-file paths so two tabs
+   in the same browser don't stomp each other's filtered/displayed/search
+   caches.
+
+   We can't redefine the CA_PATHS constant, so this test exercises the
+   behavior by re-running the regex check directly. */
+
+require_once __DIR__ . "/lib.php";
+
+echo "=== \$_POST['tabId'] regex (^[A-Za-z0-9_-]{8,64}$) ===\n";
+
+$pattern = '/^[A-Za-z0-9_-]{8,64}$/';
+
+// Valid tab IDs
+$valid = [
+	"abcd1234",                        // 8 chars (min)
+	"abcdefghABCDEFGH01234567",        // mixed case + digits
+	"tab_with_underscores_only_aaa",
+	"tab-with-hyphens-only-aaa",
+	str_repeat("a", 64),               // 64 chars (max)
+];
+foreach ($valid as $v) {
+	ok("accepts: '" . substr($v, 0, 16) . (strlen($v) > 16 ? "..." : "") . "' (" . strlen($v) . " chars)",
+	   (bool)preg_match($pattern, $v));
+}
+
+// Invalid tab IDs
+$invalid = [
+	""                              => "empty string",
+	"short"                         => "7 chars (under min)",
+	str_repeat("a", 65)             => "65 chars (over max)",
+	"tab id with spaces"            => "contains spaces",
+	"tab.with.dots"                 => "contains dots",
+	"tab/with/slashes"              => "contains slashes (path traversal attempt)",
+	"../../etc/passwd"              => "directory traversal",
+	"tab\nnewline"                  => "contains newline",
+	"tab\$with\$special"            => "contains shell metacharacters",
+	"<script>alert(1)</script>"     => "HTML injection attempt",
+];
+foreach ($invalid as $v => $note) {
+	ok("rejects: {$note}",  preg_match($pattern, $v) === 0);
+}
+
+echo "\n=== CA_PATHS structure ===\n";
+
+/* require_once paths.php inside this scope after the request env is faked,
+   so we can read CA_PATHS without triggering the live cache-suffix logic.
+   We don't set $_POST['tabId'], so the suffix must be empty. */
+$_POST = [];
+require_once "/usr/local/emhttp/plugins/community.applications/include/paths.php";
+
+ok("CA_PATHS is defined as a constant",       defined("CA_PATHS"));
+ok("CA_PATHS is an array",                    is_array(CA_PATHS));
+
+// Per-tab suffixed paths — without a tabId, no suffix
+$untabbed_keys = [
+	"community-templates-displayed",
+	"community-templates-allSearchResults",
+	"community-templates-catSearchResults",
+	"startupDisplayed",
+	"repositoriesDisplayed",
+	"sortOrder",
+	"dockerSearchResults",
+	"dockerSearchActive",
+];
+foreach ($untabbed_keys as $k) {
+	ok("CA_PATHS['{$k}'] exists and is a string",
+	   isset(CA_PATHS[$k]) && is_string(CA_PATHS[$k]));
+	$path = CA_PATHS[$k];
+	/* When tabId is unset, the per-tab paths shouldn't carry a literal suffix
+	   like ".tab123" — they should look like the bare path. */
+	ok("CA_PATHS['{$k}'] has no per-tab suffix without \$_POST['tabId']",
+	   !preg_match('/\.[A-Za-z0-9_-]{8,64}\.json$|\.[A-Za-z0-9_-]{8,64}$/', $path),
+	   $path);
+}
+
+// Other key paths exist
+$expected_keys = [
+	"tempFiles",
+	"flashDrive",
+	"templates-community",
+	"application-feed",
+	"application-feed-last-updated",
+	"unRaidVersion",
+	"unRaidVars",
+	"docker_cfg",
+	"pluginPending",
+	"dockerManTemplates",
+];
+foreach ($expected_keys as $k) {
+	ok("CA_PATHS['{$k}'] is set",  isset(CA_PATHS[$k]) && CA_PATHS[$k] !== "");
+}
+
+// Production safety: localONLY and humanReadable must NEVER be true in a release
+ok("CA_PATHS['localONLY'] is FALSE (must never ship as true)",
+   isset(CA_PATHS['localONLY']) && CA_PATHS['localONLY'] === false);
+ok("CA_PATHS['humanReadable'] is FALSE (must never ship as true)",
+   isset(CA_PATHS['humanReadable']) && CA_PATHS['humanReadable'] === false);
+
+suite_done();

--- a/tests/test_sanitizer.php
+++ b/tests/test_sanitizer.php
@@ -1,0 +1,175 @@
+<?php
+/* End-to-end tests for the README/changelog markdown sanitizer pipeline.
+
+   Replicates the inline anchor/img sanitizer logic from include/exec.php's
+   caDownloadAndRenderReadme / caDownloadAndRenderTemplateChanges so the test
+   harness can call it directly with synthetic input.
+
+   Validates:
+     - strip_tags() removes raw HTML before markdown sees it
+     - markdown links / images get rebuilt with positive attribute whitelist
+       (href/src + alt/title only, target/rel forced)
+     - href / src must pass caIsPublicHttpUrl, else wrapper stripped / image removed
+     - title-attribute injection attempts (quote-break, onclick text inside
+       title) are sealed by htmlspecialchars(ENT_QUOTES) on emit
+*/
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/dynamix/include/MarkdownExtra.inc.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+function ca_render_markdown(string $raw): string {
+	$cleaned = strip_tags($raw);
+	$html = Markdown($cleaned);
+	$html = preg_replace_callback(
+		"/<a\\b([^>]*)>(.*?)<\\/a>/is",
+		static function ($m) {
+			$attrs = $m[1]; $inner = $m[2];
+			if (preg_match("/\\bhref\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))/i", $attrs, $h)) {
+				$href = ($h[2] ?? "") ?: (($h[3] ?? "") ?: ($h[4] ?? ""));
+				if (caIsPublicHttpUrl($href)) {
+					$safeHref = htmlspecialchars($href, ENT_QUOTES);
+					$titleHtml = "";
+					if (preg_match("/\\btitle\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))/i", $attrs, $t)) {
+						$title = ($t[2] ?? "") ?: (($t[3] ?? "") ?: ($t[4] ?? ""));
+						if ($title !== "") $titleHtml = " title='".htmlspecialchars($title, ENT_QUOTES)."'";
+					}
+					return "<a href='{$safeHref}' target='_blank' rel='noopener noreferrer'{$titleHtml}>{$inner}</a>";
+				}
+			}
+			return $inner;
+		},
+		$html
+	);
+	$html = preg_replace_callback(
+		"/<(img)\\b([^>]*)>/i",
+		static function ($m) {
+			$attrs = $m[2];
+			if (preg_match("/\\bsrc\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))/i", $attrs, $s)) {
+				$src = ($s[2] ?? "") ?: (($s[3] ?? "") ?: ($s[4] ?? ""));
+				if (!caIsPublicHttpUrl($src)) return "";
+				$safeSrc = htmlspecialchars($src, ENT_QUOTES);
+				$alt = "image";
+				if (preg_match("/\\balt\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))/i", $attrs, $a)) {
+					$altRaw = ($a[2] ?? "") ?: (($a[3] ?? "") ?: ($a[4] ?? ""));
+					if ($altRaw !== "") $alt = $altRaw;
+				}
+				$titleHtml = "";
+				if (preg_match("/\\btitle\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))/i", $attrs, $t)) {
+					$title = ($t[2] ?? "") ?: (($t[3] ?? "") ?: ($t[4] ?? ""));
+					if ($title !== "") $titleHtml = " title='".htmlspecialchars($title, ENT_QUOTES)."'";
+				}
+				return "<img src='{$safeSrc}' alt='".htmlspecialchars($alt, ENT_QUOTES)."'{$titleHtml}>";
+			}
+			return "";
+		},
+		$html
+	);
+	return trim((string)$html);
+}
+
+/* Use DOMDocument to inspect the actual emitted attributes on <a> /<img> —
+   substring matches can't tell "onclick" inside a title value from a real
+   onclick attribute. */
+function ca_anchor_attrs(string $html): array {
+	$dom = new DOMDocument();
+	libxml_use_internal_errors(true);
+	$dom->loadHTML("<!DOCTYPE html><html><body>{$html}</body></html>", LIBXML_NONET);
+	libxml_clear_errors();
+	$result = [];
+	foreach ($dom->getElementsByTagName("a") as $a) {
+		$attrs = [];
+		foreach ($a->attributes as $name => $node) $attrs[strtolower($name)] = $node->nodeValue;
+		$result[] = $attrs;
+	}
+	return $result;
+}
+
+echo "=== Legitimate markdown ===\n";
+
+$out = ca_render_markdown("Visit [docs](https://docs.example.com) for info");
+ok("legit link kept with text",
+   strpos($out, "<a href='https://docs.example.com'") !== false &&
+   strpos($out, ">docs</a>") !== false,
+   $out);
+
+$out = ca_render_markdown("[doc](https://example.com \"my tooltip\")");
+ok("title attribute preserved", strpos($out, "title='my tooltip'") !== false, $out);
+
+$out = ca_render_markdown("![pic](https://example.com/img.png \"caption\")");
+ok("img with title preserved", strpos($out, "<img") !== false && strpos($out, "title='caption'") !== false, $out);
+
+$out = ca_render_markdown("**bold** and *italic* and `code`");
+ok("plain markdown formatting works",
+   strpos($out, "<strong>bold</strong>") !== false &&
+   strpos($out, "<em>italic</em>") !== false &&
+   strpos($out, "<code>code</code>") !== false,
+   $out);
+
+$out = ca_render_markdown("# Heading\n\nText here.");
+ok("heading rendered", strpos($out, "<h1>") !== false, $out);
+
+$out = ca_render_markdown("- one\n- two\n- three");
+ok("list rendered", strpos($out, "<ul>") !== false && substr_count($out, "<li>") === 3, $out);
+
+echo "\n=== Relative / scheme-less / loopback URLs ===\n";
+
+foreach ([
+	["[click](/Main/Dashboard)",                "absolute internal path"],
+	["[click](javascript:alert(1))",            "javascript: scheme"],
+	["[click](http://localhost/admin)",         "localhost"],
+	["[click](http://192.168.1.1/x)",           "private LAN IPv4"],
+	["[click](http://10.0.0.5/x)",              "10/8 LAN"],
+	["[click](http://[::1]/x)",                 "IPv6 loopback"],
+	["[click](http://[fc00::1]/x)",             "IPv6 ULA"],
+	["[click](https://2130706433/x)",           "decimal-encoded loopback"],
+	["[click](https://0x7f000001/x)",           "hex-encoded loopback"],
+] as [$src, $note]) {
+	$out = ca_render_markdown($src);
+	ok("link stripped ({$note}): {$src}",
+	   strpos($out, "<a") === false && strpos($out, "click") !== false,
+	   $out);
+}
+
+echo "\n=== Image gating ===\n";
+
+$out = ca_render_markdown("![pic](/local/img.png)");
+ok("relative img removed entirely", strpos($out, "<img") === false, $out);
+
+$out = ca_render_markdown("![pic](http://127.0.0.1/img.png)");
+ok("loopback img removed", strpos($out, "<img") === false, $out);
+
+echo "\n=== Raw HTML stripped before markdown ===\n";
+
+$out = ca_render_markdown("Some <script>alert('xss')</script> text");
+ok("raw <script> removed", strpos($out, "script") === false, $out);
+
+$out = ca_render_markdown("<a href='javascript:alert(1)' onclick='alert(2)'>Click</a>");
+ok("raw <a> with onclick removed", strpos($out, "javascript") === false && strpos($out, "onclick") === false, $out);
+
+$out = ca_render_markdown("<img src=x onerror=alert(1)>");
+ok("raw <img onerror> removed", strpos($out, "onerror") === false && strpos($out, "alert") === false, $out);
+
+echo "\n=== Title-attribute injection attempts (DOM-verified) ===\n";
+
+$out = ca_render_markdown('[a](https://example.com "x onclick=alert(1) y")');
+$anchors = ca_anchor_attrs($out);
+ok("'onclick' in title text doesn't become a real onclick attr",
+   count($anchors) === 1 && !isset($anchors[0]["onclick"]),
+   json_encode($anchors[0] ?? []));
+
+$out = ca_render_markdown("[a](https://example.com \"x' onclick=alert(1) y='\")");
+$anchors = ca_anchor_attrs($out);
+ok("title quote-break attempt sealed (no onclick attr)",
+   count($anchors) === 1 && !isset($anchors[0]["onclick"]),
+   json_encode($anchors[0] ?? []));
+
+$out = ca_render_markdown('[a](https://example.com" onclick="alert(1))');
+$anchors = ca_anchor_attrs($out);
+/* Markdown won't parse the malformed bracket+url as a link, so the text falls
+   through as a <p>. The literal " onclick=" substring may appear in the
+   paragraph's text content, but never as an actual <a> attribute. Verify via
+   DOM, not substring. */
+ok("URL-side injection attempt blocked (no <a> emitted)", count($anchors) === 0, $out);
+
+suite_done();

--- a/tests/test_string_helpers.php
+++ b/tests/test_string_helpers.php
@@ -1,0 +1,77 @@
+<?php
+/* Tests for the small string utilities in include/helpers.php:
+   startsWith, endsWith, first_str_replace, last_str_replace, alphaNumeric,
+   MakeReadable, ca_explode */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+echo "=== startsWith ===\n";
+ok("plain prefix",                   startsWith("hello world", "hello"));
+ok("not a prefix",                  !startsWith("hello world", "world"));
+ok("empty needle is always true",    startsWith("anything", ""));
+ok("empty haystack, non-empty needle", !startsWith("", "x"));
+ok("array of needles, one matches",  startsWith("/var/log/plugins/foo.plg", ["/usr/", "/var/", "/tmp/"]));
+ok("array of needles, none matches", !startsWith("/etc/passwd", ["/usr/", "/var/", "/tmp/"]));
+ok("non-string haystack returns false", !startsWith(123, "1"));
+ok("non-string needle returns false",   !startsWith("abc", null));
+ok("case sensitive (lowercase prefix vs upper haystack)",
+                                     !startsWith("Hello", "hello") || true);
+                                     /* Note: implementation uses strripos which is case-INsensitive
+                                        — leaving as-is to document current behavior. */
+
+echo "\n=== endsWith ===\n";
+ok("plain suffix",                   endsWith("filename.plg", ".plg"));
+ok("not a suffix",                  !endsWith("filename.plg", ".xml"));
+ok("empty needle is always true",    endsWith("anything", ""));
+ok("array of suffixes, one matches", endsWith("foo.plg", [".xml", ".plg", ".php"]));
+ok("array of suffixes, none matches", !endsWith("foo.txt", [".xml", ".plg", ".php"]));
+ok("exact match",                    endsWith("hello", "hello"));
+
+echo "\n=== first_str_replace / last_str_replace ===\n";
+eq("first replaces only first occurrence",
+   "X abc abc",
+   first_str_replace("abc abc abc", "abc", "X"));
+eq("last replaces only last occurrence",
+   "abc abc X",
+   last_str_replace("abc abc abc", "abc", "X"));
+eq("first: needle absent leaves haystack untouched",
+   "no match here",
+   first_str_replace("no match here", "xyz", "X"));
+eq("last: needle absent leaves haystack untouched",
+   "no match here",
+   last_str_replace("no match here", "xyz", "X"));
+eq("first: replacement longer than needle",
+   "very-long-replacement xyz",
+   first_str_replace("abc xyz", "abc", "very-long-replacement"));
+
+echo "\n=== alphaNumeric ===\n";
+eq("strips spaces",         "helloworld", alphaNumeric("hello world"));
+eq("strips punctuation",    "helloworld", alphaNumeric("hello, world!"));
+eq("preserves digits",      "abc123",     alphaNumeric("abc-123"));
+eq("preserves mixed case",  "AbC123",     alphaNumeric("Ab C-1 2 3"));
+eq("empty string",          "",           alphaNumeric(""));
+eq("only punctuation",      "",           alphaNumeric("!@#$%^&*()"));
+
+echo "\n=== MakeReadable ===\n";
+/* The format may evolve, so just ensure a non-empty stringy result + sensible scale. */
+$small = MakeReadable(0);
+ok("0 bytes returns something",       is_string($small) || is_numeric($small));
+
+$kb  = MakeReadable(2048);
+ok("KB scale produced",               (bool)preg_match('/k/i', (string)$kb));
+
+$mb  = MakeReadable(5 * 1024 * 1024);
+ok("MB scale produced",               (bool)preg_match('/m/i', (string)$mb));
+
+$gb  = MakeReadable(3 * 1024 * 1024 * 1024);
+ok("GB scale produced",               (bool)preg_match('/g/i', (string)$gb));
+
+echo "\n=== ca_explode (pad-to-count) ===\n";
+eq("normal split returns 2 parts",      ["host", "8080"],          ca_explode(':', 'host:8080'));
+eq("missing delimiter pads with empty", ["host", ""],              ca_explode(':', 'host'));
+eq("count=3 splits at most twice",      ["a", "b", "c:d"],         ca_explode(':', 'a:b:c:d', 3));
+eq("count=3 short input pads to 3",     ["a", "", ""],             ca_explode(':', 'a', 3));
+eq("empty input pads to count",         ["", ""],                  ca_explode(':', ''));
+
+suite_done();

--- a/tests/test_string_helpers.php
+++ b/tests/test_string_helpers.php
@@ -15,10 +15,11 @@ ok("array of needles, one matches",  startsWith("/var/log/plugins/foo.plg", ["/u
 ok("array of needles, none matches", !startsWith("/etc/passwd", ["/usr/", "/var/", "/tmp/"]));
 ok("non-string haystack returns false", !startsWith(123, "1"));
 ok("non-string needle returns false",   !startsWith("abc", null));
-ok("case sensitive (lowercase prefix vs upper haystack)",
-                                     !startsWith("Hello", "hello") || true);
-                                     /* Note: implementation uses strripos which is case-INsensitive
-                                        — leaving as-is to document current behavior. */
+/* Implementation uses strripos which is case-INsensitive — pin that
+   behavior so a future change to strrpos (case-sensitive) would break the
+   test instead of silently changing semantics. */
+ok("case-insensitive prefix match (current behavior, intentional)",
+   startsWith("Hello", "hello"));
 
 echo "\n=== endsWith ===\n";
 ok("plain suffix",                   endsWith("filename.plg", ".plg"));

--- a/tests/test_strip_image_tag.php
+++ b/tests/test_strip_image_tag.php
@@ -1,0 +1,46 @@
+<?php
+/* Tests for PreviousAppsHelpers::stripImageTag()
+   The "colon after the last slash" rule that distinguishes a docker tag
+   (which we want to strip) from a registry port (which we want to keep). */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/previous_apps_helpers.php";
+
+/* The method is private static — reach in via Reflection. */
+$ref = new ReflectionMethod("PreviousAppsHelpers", "stripImageTag");
+$ref->setAccessible(true);
+$strip = function (string $repo) use ($ref) { return $ref->invoke(null, $repo); };
+
+echo "=== stripImageTag ===\n";
+
+$cases = [
+	// Plain images
+	["library/foo",                          "library/foo",          "no tag, plain"],
+	["library/foo:latest",                   "library/foo",          "tagged"],
+	["library/foo:1.2.3",                    "library/foo",          "version tag"],
+	["library/foo:sha-abc123",               "library/foo",          "sha tag"],
+
+	// Single-segment images
+	["foo",                                  "foo",                  "single segment, no tag"],
+	["foo:latest",                           "foo",                  "single segment, tagged"],
+
+	// Registry with port — colon BEFORE the last slash, must be preserved
+	["registry:5000/repo",                   "registry:5000/repo",   "registry port, no tag"],
+	["registry:5000/repo:latest",            "registry:5000/repo",   "registry port + tag"],
+	["registry:5000/ns/app:1.0",             "registry:5000/ns/app", "registry port + nested ns + tag"],
+	["registry.example.com:443/repo:v2",     "registry.example.com:443/repo", "fqdn:port + tag"],
+
+	// Registry without port — no tag
+	["ghcr.io/owner/repo",                   "ghcr.io/owner/repo",   "ghcr no tag"],
+	["ghcr.io/owner/repo:latest",            "ghcr.io/owner/repo",   "ghcr tagged"],
+
+	// Edge cases
+	["",                                     "",                     "empty string"],
+	[":latest",                              "",                     "leading colon (no name)"],
+];
+
+foreach ($cases as [$in, $expected, $note]) {
+	eq("strip ({$note}): {$in}", $expected, $strip($in));
+}
+
+suite_done();

--- a/tests/test_template_normalization.php
+++ b/tests/test_template_normalization.php
@@ -1,0 +1,193 @@
+<?php
+/* Tests for the template-normalization helpers in include/helpers.php:
+   addMissingVars, removeXMLtags, fixAttributes, fixTemplates.
+
+   makeXML is intentionally NOT covered here — it depends on Array2XML which
+   is loaded by the dynamix DockerClient bootstrap (not loaded in tests). */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+$_POST = [];
+require_once "/usr/local/emhttp/plugins/community.applications/include/paths.php";
+
+ca_test_load_fixtures();
+$GLOBALS['caSettings']['unRaidVersion'] = "7.0.0";
+
+echo "=== addMissingVars (PHP 8 compliance: stamp known-key defaults onto a template) ===\n";
+
+$template = [
+	"Name"       => "Test App",
+	"Repository" => "test/app",
+];
+$out = addMissingVars($template);
+
+ok("preserves Name",        ($out['Name']       ?? null) === "Test App");
+ok("preserves Repository",  ($out['Repository'] ?? null) === "test/app");
+/* Implementation stamps a fixed list of expected keys onto the array — pick a
+   handful that production reads from the template. (Compatible isn't in the
+   list — it's set by versionCheck-time logic, not stamped here.) */
+foreach (["Category", "MinVer", "MaxVer", "Beta", "Plugin", "Deprecated", "Blacklist"] as $expected) {
+	ok("stamps default for missing '{$expected}'",  array_key_exists($expected, $out));
+}
+
+eq("non-array input passes through (string)",
+   "string",
+   addMissingVars("string"));
+eq("non-array input passes through (null)",
+   null,
+   addMissingVars(null));
+eq("non-array input passes through (int)",
+   42,
+   addMissingVars(42));
+
+$preserved = ["Category" => "Media", "MinVer" => "6.10"];
+$out2 = addMissingVars($preserved);
+eq("existing values preserved (Category)",  "Media",  $out2['Category']);
+eq("existing values preserved (MinVer)",    "6.10",   $out2['MinVer']);
+
+echo "\n=== removeXMLtags (recursive in-place tag stripping) ===\n";
+
+$tpl = ["Description" => "<b>Bold</b> and <i>italic</i> text"];
+removeXMLtags($tpl);
+ok("strips <b>",  strpos($tpl['Description'], "<b>") === false, $tpl['Description']);
+ok("strips <i>",  strpos($tpl['Description'], "<i>") === false, $tpl['Description']);
+ok("preserves text content",
+   strpos($tpl['Description'], "Bold") !== false &&
+   strpos($tpl['Description'], "italic") !== false,
+   $tpl['Description']);
+
+/* Nested arrays — recursion */
+$tpl = [
+	"App" => [
+		"Name"        => "<i>Styled</i>",
+		"Description" => "<b>Bold</b>",
+	],
+];
+removeXMLtags($tpl);
+ok("recurses into nested arrays (Name tags stripped)",
+   strpos($tpl['App']['Name'], "<") === false,
+   $tpl['App']['Name']);
+ok("recurses into nested arrays (Description tags stripped)",
+   strpos($tpl['App']['Description'], "<") === false,
+   $tpl['App']['Description']);
+
+/* <br> handling quirk: implementation converts <br>→\n and only writes back
+   if trim(text) !== trim(strip_tags(text)). When the only "tag" is <br>, after
+   conversion both sides are equal, so the write-back is skipped — element
+   stays untouched. Document that quirk. <br> only gets normalized when it
+   appears alongside *other* tags that would actually trigger the rewrite. */
+$tpl = ["Description" => "Line 1<br>Line 2"];
+removeXMLtags($tpl);
+eq("plain <br> alone left untouched (quirk: only rewrites when other tags present)",
+   "Line 1<br>Line 2",
+   $tpl['Description']);
+
+$tpl = ["Description" => "<b>Bold</b><br>Plain"];
+removeXMLtags($tpl);
+ok("<br> normalized when accompanied by other tags",
+   strpos($tpl['Description'], "<br>") === false &&
+   strpos($tpl['Description'], "Bold")  !== false &&
+   strpos($tpl['Description'], "Plain") !== false,
+   $tpl['Description']);
+
+/* Plain string without tags — left alone */
+$tpl = ["Description" => "no tags here"];
+removeXMLtags($tpl);
+eq("plain string passes through",  "no tags here",  $tpl['Description']);
+
+/* Null/missing values */
+$tpl = ["Description" => null];
+removeXMLtags($tpl);
+ok("null value handled without warning",  array_key_exists("Description", $tpl));
+
+echo "\n=== fixAttributes (normalize @attributes container) ===\n";
+
+/* Single Config entry with @attributes — wraps into an array of one */
+$tpl = ["Config" => ["@attributes" => ["Type" => "Port", "Default" => "8080"]]];
+fixAttributes($tpl, "Config");
+ok("single-entry Config wrapped into array of one",
+   isset($tpl['Config'][0]['@attributes']),
+   var_export($tpl, true));
+
+/* Already-wrapped Config (multiple entries) — unchanged shape */
+$tpl = ["Config" => [
+	["@attributes" => ["Type" => "Port", "Default" => "8080"]],
+	["@attributes" => ["Type" => "Variable", "Default" => "X"]],
+]];
+$snapshot = $tpl;
+fixAttributes($tpl, "Config");
+ok("already-wrapped Config preserved",  $tpl === $snapshot);
+
+/* Missing attribute → no-op */
+$tpl = ["Name" => "Foo"];
+$snapshot = $tpl;
+fixAttributes($tpl, "Config");
+ok("missing attribute → no-op",  $tpl === $snapshot);
+
+/* Non-array attribute → no-op */
+$tpl = ["Config" => "not an array"];
+$snapshot = $tpl;
+fixAttributes($tpl, "Config");
+ok("scalar attribute → no-op",  $tpl === $snapshot);
+
+echo "\n=== fixTemplates (defaulting + boolean coercion) ===\n";
+
+/* MinVer defaulting — non-plugin gets 6.0 */
+$out = fixTemplates(["Name" => "Foo"]);
+eq("non-plugin template defaults MinVer to 6.0",  "6.0",  $out['MinVer']);
+
+/* MinVer defaulting — plugin gets 6.1 */
+$out = fixTemplates(["Name" => "FooPlugin", "Plugin" => true]);
+eq("plugin template defaults MinVer to 6.1",  "6.1",  $out['MinVer']);
+
+/* MinVer already set — preserved */
+$out = fixTemplates(["MinVer" => "7.5"]);
+eq("existing MinVer preserved",  "7.5",  $out['MinVer']);
+
+/* Deprecated/Blacklist boolean coercion — appfeed sometimes ships strings */
+$out = fixTemplates(["Deprecated" => "true"]);
+ok("Deprecated 'true' string → true bool",   $out['Deprecated'] === true);
+
+$out = fixTemplates(["Deprecated" => "false"]);
+ok("Deprecated 'false' string → false bool", $out['Deprecated'] === false);
+
+$out = fixTemplates(["Blacklist" => "1"]);
+ok("Blacklist '1' string → true bool",       $out['Blacklist'] === true);
+
+$out = fixTemplates(["Blacklist" => 0]);
+ok("Blacklist int 0 → false bool",           $out['Blacklist'] === false);
+
+$out = fixTemplates([]);
+ok("missing Deprecated → false bool",        $out['Deprecated'] === false);
+ok("missing Blacklist → false bool",         $out['Blacklist'] === false);
+
+/* DeprecatedMaxVer flips Deprecated when current Unraid version exceeds it */
+$out = fixTemplates(["DeprecatedMaxVer" => "6.12"]);  // current 7.0.0 > 6.12
+ok("DeprecatedMaxVer past current OS → marks Deprecated",   $out['Deprecated'] === true);
+
+$out = fixTemplates(["DeprecatedMaxVer" => "8.0"]);   // current 7.0.0 < 8.0
+ok("DeprecatedMaxVer ahead of current OS → no force-deprecate",
+   $out['Deprecated'] === false);
+
+/* Config Description scrubbing — generic placeholders get cleared */
+$out = fixTemplates([
+	"Config" => ["@attributes" => [
+		"Type"        => "Path",
+		"Description" => "Container Path: /data",
+	]],
+]);
+eq("'Container Path:' description scrubbed",
+   "",
+   $out['Config']['@attributes']['Description']);
+
+$out = fixTemplates([
+	"Config" => ["@attributes" => [
+		"Type"        => "Variable",
+		"Description" => "User-provided meaningful text",
+	]],
+]);
+eq("user-supplied description preserved",
+   "User-provided meaningful text",
+   $out['Config']['@attributes']['Description']);
+
+suite_done();

--- a/tests/test_template_ports.php
+++ b/tests/test_template_ports.php
@@ -1,0 +1,156 @@
+<?php
+/* Tests for portsUsed() and adjustTemplatePorts() — both touch the
+   $template['Config'] structure that templates use to declare host/container
+   port mappings. */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+echo "=== portsUsed ===\n";
+
+// Non-bridge / no Config → []
+eq("no template → []",
+   "[]",
+   portsUsed(null));
+
+eq("template without Config → []",
+   "[]",
+   portsUsed(["Network" => "bridge"]));
+
+eq("non-bridge network → []",
+   "[]",
+   portsUsed(["Network" => "host", "Config" => [["@attributes" => ["Type" => "Port", "Default" => "8080"]]]]));
+
+// Single-port (bridge)
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [
+		["@attributes" => ["Type" => "Port", "Default" => "8080"]],
+	],
+];
+eq("single port from Default", "[8080]", portsUsed($tpl));
+
+// Multiple ports — Default values
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [
+		["@attributes" => ["Type" => "Port", "Default" => "8080"]],
+		["@attributes" => ["Type" => "Port", "Default" => "8443"]],
+		["@attributes" => ["Type" => "Variable", "Default" => "X"]],   // ignored
+		["@attributes" => ["Type" => "Path",     "Default" => "/foo"]], // ignored
+		["@attributes" => ["Type" => "Port",     "Default" => "9000"]],
+	],
+];
+eq("multiple Port entries, non-Port entries skipped",
+   "[8080,8443,9000]",
+   portsUsed($tpl));
+
+// User override via "value" — wins over Default
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [
+		["@attributes" => ["Type" => "Port", "Default" => "8080"], "value" => "32400"],
+	],
+];
+eq("'value' overrides Default",
+   "[32400]",
+   portsUsed($tpl));
+
+// Single Config (single port) presented as @attributes-on-the-Config-itself
+$tpl = [
+	"Network" => "bridge",
+	"Config" => ["@attributes" => ["Type" => "Port", "Default" => "8080"]],
+];
+eq("Config with @attributes directly (single-port form)",
+   "[8080]",
+   portsUsed($tpl));
+
+echo "\n=== adjustTemplatePorts ===\n";
+
+// No Config → no-op
+$tpl = ["Network" => "bridge"];
+adjustTemplatePorts($tpl, [80, 443]);
+ok("no Config → no-op (template unchanged)", $tpl === ["Network" => "bridge"]);
+
+// Non-bridge → no-op even with conflicting ports
+$tpl = [
+	"Network" => "host",
+	"Config" => [["@attributes" => ["Type" => "Port", "Default" => "8080"], "value" => "8080"]],
+];
+$snapshot = $tpl;
+adjustTemplatePorts($tpl, [8080]);
+ok("non-bridge → no-op", $tpl === $snapshot);
+
+// Default port not in use → unchanged
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [["@attributes" => ["Type" => "Port", "Default" => "8080"], "value" => "8080"]],
+];
+adjustTemplatePorts($tpl, [80, 443]);
+eq("port 8080 not taken → stays 8080",
+   "8080",
+   $tpl["Config"][0]["value"]);
+
+// Default port already in use → bumped
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [["@attributes" => ["Type" => "Port", "Default" => "8080"], "value" => "8080"]],
+];
+adjustTemplatePorts($tpl, [8080]);
+eq("port 8080 taken → bumped to 8081",
+   "8081",
+   $tpl["Config"][0]["value"]);
+
+// Cluster of taken ports → finds first free
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [["@attributes" => ["Type" => "Port", "Default" => "8080"], "value" => "8080"]],
+];
+adjustTemplatePorts($tpl, [8080, 8081, 8082, 8083]);
+eq("8080-8083 taken → bumped to 8084",
+   "8084",
+   $tpl["Config"][0]["value"]);
+
+// Multiple ports in same template — second port shouldn't collide with the
+// first port we already placed
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [
+		["@attributes" => ["Type" => "Port", "Default" => "8080"], "value" => "8080"],
+		["@attributes" => ["Type" => "Port", "Default" => "8081"], "value" => "8081"],
+	],
+];
+adjustTemplatePorts($tpl, [8080]);
+/* First port: 8080 taken → bumped to 8081. Second port: Default 8081, but
+   we just used 8081 for the first one → bump to 8082. */
+eq("first port bumped to 8081",  "8081", $tpl["Config"][0]["value"]);
+eq("second port bumped past first's new value",
+   "8082",
+   $tpl["Config"][1]["value"]);
+
+// Non-Port Config entries left untouched
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [
+		["@attributes" => ["Type" => "Variable", "Target" => "TZ", "Default" => "UTC"], "value" => "UTC"],
+		["@attributes" => ["Type" => "Port",     "Default" => "8080"], "value" => "8080"],
+	],
+];
+adjustTemplatePorts($tpl, [8080]);
+eq("Variable entry untouched",  "UTC",  $tpl["Config"][0]["value"]);
+eq("Port entry bumped",         "8081", $tpl["Config"][1]["value"]);
+
+// Out-of-range ports: ignored
+$tpl = [
+	"Network" => "bridge",
+	"Config" => [
+		["@attributes" => ["Type" => "Port", "Default" => "0"],     "value" => "0"],
+		["@attributes" => ["Type" => "Port", "Default" => "70000"], "value" => "70000"],
+	],
+];
+$snapshot = $tpl;
+adjustTemplatePorts($tpl, [8080]);
+ok("port 0 left untouched",        $tpl["Config"][0]["value"] === "0");
+ok("port > 65535 left untouched",  $tpl["Config"][1]["value"] === "70000");
+
+suite_done();

--- a/tests/test_url_validation.php
+++ b/tests/test_url_validation.php
@@ -1,0 +1,103 @@
+<?php
+/* Tests for the URL validation surface in include/helpers.php:
+     - validURL($url)               — used by template/feed-data emit sites
+     - caIsPrivateOrLoopbackHost($host)
+     - caIsPublicHttpUrl($url)      — stricter variant used in README/changelog sanitizers
+
+   Run on the server (where the live plugin lives):
+     php /mnt/user/GitHub/community.applications/tests/test_url_validation.php
+*/
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+
+echo "=== validURL ===\n";
+
+// Non-URL / scheme rejection
+foreach (["", "/Main", "/Main/Dashboard", "Settings/Tailscale", "javascript:alert(1)",
+          "data:text/html,<script>", "file:///etc/passwd", "ftp://example.com",
+          "ssh://user@host", "mailto:x@y.com", "tel:+15555555555", "vbscript:msgbox(1)",
+          "//example.com/path"] as $u) {
+	ok("validURL rejects: '{$u}'", !validURL($u));
+}
+
+// Loopback / private — validURL also rejects these (it shares the same loopback-host check)
+foreach (["http://localhost", "https://127.0.0.1", "http://[::1]/x", "http://0.0.0.0",
+          "http://2130706433", "http://0x7f000001"] as $u) {
+	ok("validURL rejects loopback: '{$u}'", !validURL($u));
+}
+
+// Real public URLs
+foreach (["http://example.com", "https://github.com/user/repo",
+          "https://docs.example.com/path?q=1#frag", "http://8.8.8.8/"] as $u) {
+	ok("validURL accepts: '{$u}'", (bool)validURL($u));
+}
+
+// Case-insensitive scheme
+ok("validURL accepts uppercase HTTPS://", (bool)validURL("HTTPS://example.com"));
+
+echo "\n=== caIsPrivateOrLoopbackHost — IPv4 private/loopback ===\n";
+$private_v4 = [
+	"localhost", "127.0.0.1", "127.255.255.254",
+	"10.0.0.1", "10.255.255.255",
+	"172.16.0.1", "172.31.255.255",
+	"192.168.1.1", "169.254.1.1",
+	"0.0.0.0", "0",
+];
+foreach ($private_v4 as $h) ok("private IPv4: {$h}", caIsPrivateOrLoopbackHost($h));
+
+echo "\n=== caIsPrivateOrLoopbackHost — IPv6 private/loopback ===\n";
+$private_v6 = [
+	"::1", "[::1]", "::", "fc00::1", "fd00::1", "fe80::1",
+	"::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:192.168.1.1",
+];
+foreach ($private_v6 as $h) ok("private IPv6: {$h}", caIsPrivateOrLoopbackHost($h));
+
+echo "\n=== caIsPrivateOrLoopbackHost — encoded IPv4 bypass forms ===\n";
+foreach (["2130706433" => "decimal 127.0.0.1",
+          "0x7f000001" => "hex 127.0.0.1",
+          "0xc0a80101" => "hex 192.168.1.1"] as $h => $note) {
+	ok("private encoded ({$note}): {$h}", caIsPrivateOrLoopbackHost($h));
+}
+
+echo "\n=== caIsPrivateOrLoopbackHost — public hosts (must NOT be flagged) ===\n";
+$public_hosts = [
+	"example.com", "github.com",
+	"8.8.8.8", "1.1.1.1",
+	"172.15.0.1", "172.32.0.1",       // edges of 172.16-31 range
+	"192.167.1.1", "192.169.1.1",     // edges of 192.168
+	"169.253.1.1", "169.255.1.1",     // edges of 169.254
+	"11.0.0.1",                        // adjacent to 10.x
+	"126.0.0.1", "128.0.0.1",         // edges of 127.x
+	"2001:4860:4860::8888",            // public IPv6 (Google DNS)
+];
+foreach ($public_hosts as $h) ok("public host: {$h}", !caIsPrivateOrLoopbackHost($h));
+
+echo "\n=== caIsPublicHttpUrl ===\n";
+
+// Schemes other than http(s)
+foreach (["", "/Main/Dashboard", "javascript:alert(1)", "data:text/html,<script>",
+          "file:///etc/passwd", "ftp://example.com", "mailto:x@y.com",
+          "ssh://user@host/cmd", "vnc://host:5900", "rdp://internal-server",
+          "smb://fileserver/share"] as $u) {
+	ok("rejects non-http(s): '{$u}'", !caIsPublicHttpUrl($u));
+}
+
+// Loopback / private
+foreach (["http://localhost", "https://127.0.0.1", "http://192.168.1.1/",
+          "http://10.0.0.1", "http://[::1]/", "http://[fe80::1]/",
+          "http://[fc00::1]/", "http://2130706433/", "http://0x7f000001/"] as $u) {
+	ok("rejects private/loopback: '{$u}'", !caIsPublicHttpUrl($u));
+}
+
+// Real public URLs
+foreach (["http://example.com", "https://github.com/user/repo",
+          "https://docs.example.com/path?q=1#frag",
+          "https://[2001:4860:4860::8888]/", "http://8.8.8.8/"] as $u) {
+	ok("accepts public: '{$u}'", caIsPublicHttpUrl($u));
+}
+
+// Case-insensitivity
+ok("accepts uppercase HTTPS://", caIsPublicHttpUrl("HTTPS://example.com"));
+
+suite_done();

--- a/tests/test_version_check.php
+++ b/tests/test_version_check.php
@@ -1,0 +1,117 @@
+<?php
+/* Tests for versionCheck() — gates whether a template is compatible with the
+   current Unraid version, considering MinVer / MaxVer / IncompatibleVersion.
+
+   Reads $GLOBALS['caSettings']['unRaidVersion'], so we use ca_test_load_fixtures()
+   to seed it, then override per-case as needed. */
+
+require_once __DIR__ . "/lib.php";
+require_once "/usr/local/emhttp/plugins/community.applications/include/helpers.php";
+$_POST = [];
+require_once "/usr/local/emhttp/plugins/community.applications/include/paths.php";
+
+ca_test_load_fixtures();
+
+/* All cases run against a fixed "current" Unraid version. */
+$GLOBALS['caSettings']['unRaidVersion'] = "7.0.0";
+
+echo "=== versionCheck (current Unraid 7.0.0) ===\n";
+
+ok("template with no version constraints passes",
+   versionCheck([]));
+
+ok("template with empty constraints passes",
+   versionCheck(["MinVer" => null, "MaxVer" => null]));
+
+echo "\n=== MinVer ===\n";
+
+ok("MinVer = 6.10 (≤ 7.0.0) → pass",
+   versionCheck(["MinVer" => "6.10"]));
+
+ok("MinVer = 7.0 (≤ 7.0.0) → pass",
+   versionCheck(["MinVer" => "7.0"]));
+
+ok("MinVer = 7.0.0 (== 7.0.0) → pass",
+   versionCheck(["MinVer" => "7.0.0"]));
+
+ok("MinVer = 7.1 (> 7.0.0) → fail",
+   ! versionCheck(["MinVer" => "7.1"]));
+
+ok("MinVer = 8.0 (> 7.0.0) → fail",
+   ! versionCheck(["MinVer" => "8.0"]));
+
+echo "\n=== MaxVer ===\n";
+
+/* PHP's version_compare treats "7.0" as version_compare("7.0","7.0.0") = -1
+   (the missing third component is treated as less than 0). So MaxVer="7.0"
+   actually FAILS at current 7.0.0 — pin that behavior to catch surprise
+   regressions. If users were burned by this we'd consider normalizing in
+   the function itself. */
+ok("MaxVer = 7.0 → fail at 7.0.0 (PHP version_compare quirk: 7.0 < 7.0.0)",
+   ! versionCheck(["MaxVer" => "7.0"]));
+
+ok("MaxVer = 7.0.0 (== 7.0.0) → pass",
+   versionCheck(["MaxVer" => "7.0.0"]));
+
+ok("MaxVer = 7.5 (> 7.0.0) → pass",
+   versionCheck(["MaxVer" => "7.5"]));
+
+ok("MaxVer = 6.12.99 (< 7.0.0) → fail",
+   ! versionCheck(["MaxVer" => "6.12.99"]));
+
+ok("MaxVer = 6.7.9 (< 7.0.0) → fail",
+   ! versionCheck(["MaxVer" => "6.7.9"]));
+
+echo "\n=== Both MinVer and MaxVer ===\n";
+
+ok("MinVer 6.10 + MaxVer 7.5 (current 7.0.0 in range) → pass",
+   versionCheck(["MinVer" => "6.10", "MaxVer" => "7.5"]));
+
+ok("MinVer 7.5 + MaxVer 8.0 (current below range) → fail",
+   ! versionCheck(["MinVer" => "7.5", "MaxVer" => "8.0"]));
+
+ok("MinVer 5.0 + MaxVer 6.12 (current above range) → fail",
+   ! versionCheck(["MinVer" => "5.0", "MaxVer" => "6.12"]));
+
+echo "\n=== IncompatibleVersion (block specific plugin versions) ===\n";
+
+ok("plugin v1.2.3 not in IncompatibleVersion list → pass",
+   versionCheck([
+	"pluginVersion" => "1.2.3",
+	"IncompatibleVersion" => ["1.0.0", "1.1.0"],
+   ]));
+
+ok("plugin v1.0.0 IN IncompatibleVersion array → fail",
+   ! versionCheck([
+	"pluginVersion" => "1.0.0",
+	"IncompatibleVersion" => ["1.0.0", "1.1.0"],
+   ]));
+
+ok("plugin v1.0.0 in IncompatibleVersion as scalar (not array) → fail",
+   ! versionCheck([
+	"pluginVersion" => "1.0.0",
+	"IncompatibleVersion" => "1.0.0",
+   ]));
+
+ok("plugin v2.0.0, IncompatibleVersion scalar 1.0.0 → pass",
+   versionCheck([
+	"pluginVersion" => "2.0.0",
+	"IncompatibleVersion" => "1.0.0",
+   ]));
+
+echo "\n=== Edge cases ===\n";
+
+ok("MinVer with non-numeric suffix (RC) handled",
+   ! versionCheck(["MinVer" => "7.1.0-rc1"]) ||
+     versionCheck(["MinVer" => "7.1.0-rc1"]));   /* version_compare semantics — just ensure no crash */
+
+/* Reset to a different Unraid version and verify behavior changes accordingly. */
+$GLOBALS['caSettings']['unRaidVersion'] = "6.11.5";
+
+ok("at 6.11.5: MaxVer 6.11.9 → pass (< 7.0.0 case becomes valid)",
+   versionCheck(["MaxVer" => "6.11.9"]));
+
+ok("at 6.11.5: MinVer 7.0 → fail",
+   ! versionCheck(["MinVer" => "7.0"]));
+
+suite_done();


### PR DESCRIPTION
## Summary

Adds a `tests/` directory at the repo root with a lightweight PHP unit-test
harness for CA's helper / utility surface.

**Where:** `/tests/` lives **outside** `source/community.applications/`, which
is the directory `pkg_build.sh` packages. The tests are therefore never
included in the distributed `.txz` — they're local-CI / dev-loop only.

**No production code changes.** This PR only adds the `tests/` directory.

## What's covered

313 assertions across 12 suites:

| Suite | Coverage | Asserts |
|---|---|---:|
| `test_url_validation.php` | `validURL`, `caIsPublicHttpUrl`, `caIsPrivateOrLoopbackHost` (loopback, IPv4 private ranges, IPv6 ULA/link-local, IPv4-mapped IPv6 loopback, decimal/hex IPv4 bypass forms) | 87 |
| `test_path_helpers.php` | `$_POST['tabId']` regex hardening (path-traversal/HTML-injection forms rejected), `CA_PATHS` structure, production safety asserts (`localONLY`/`humanReadable` MUST be false) | 45 |
| `test_string_helpers.php` | `startsWith`, `endsWith`, `first_str_replace`, `last_str_replace`, `alphaNumeric`, `MakeReadable`, `ca_explode` | 35 |
| `test_sanitizer.php` | README/changelog markdown pipeline — strip raw HTML before markdown, rebuild `<a>`/`<img>` with positive attribute whitelist, DOM-verified attribute-injection sealing | 23 |
| `test_globals_fixture.php` | `ca_test_load_fixtures()` helper + `getAuthor`, `mySort`, `repositorySort`, `favouriteSort` | 21 |
| `test_array_helpers.php` | `searchArray`, `duplicateArrayWithoutKeys`, `filterMatch` | 19 |
| `test_template_ports.php` | `portsUsed`, `adjustTemplatePorts` (port collisions, Variable entries untouched, out-of-range guards) | 18 |
| `test_autocomplete.php` | `PopulateAutoCompleteHelpers::stripPrefix` / `addRepositorySuggestion` / `buildBaseSuggestions` | 15 |
| `test_strip_image_tag.php` | `PreviousAppsHelpers::stripImageTag` — colon-after-last-slash rule that keeps `registry:5000/repo` ports intact while stripping `:tag` | 14 |
| `test_fix_description.php` | `fixDescription` — de-greeded span regex, legacy `[br]`/`[b]` markup handling, raw HTML scrubbing | 13 |
| `test_json_io.php` | `readJsonFile` (serialized + JSON + garbage), `ca_file_put_contents` (atomic `.~` rename) | 13 |
| `test_youtube_thumbnail.php` | `getYoutubeThumbnail` — `youtu.be` / `watch?v=` forms | 10 |

## Infrastructure

- **`lib.php`** — tiny `ok()` / `eq()` / `suite_done()` framework. No PHPUnit. No composer.
- **`lib.php`** — `_()` and `tr()` stubs that return their input verbatim, so any function under test that calls `tr()` works without the dynamix translations bootstrap.
- **`lib.php`** — `ca_test_load_fixtures()` mirrors `getGlobals()` / `getSettings()` for the test environment. `$GLOBALS['templates']` is populated from the live `/tmp/community.applications/tempFiles/templates_new.json` cache via the same `readJsonFile()` production uses (format detection, serialize/JSON), falling back to `[]` on hosts without the cache. Permissive `caSettings` / `sortOrder` / `action` defaults that individual tests can override per-key.
- **`run.sh`** — one-shot orchestrator. SSHes to the server and runs every `test_*.php`; aggregates suite exit codes. `CA_TEST_HOST=root@another.host ./run.sh` overrides the host.
- **`README.md`** — layout, conventions, how to add new tests.

## How to run

```sh
cd tests && ./run.sh
```

The tests need to execute on a host where the live plugin is installed, because they `require_once` files under `/usr/local/emhttp/plugins/community.applications/` and the dynamix `MarkdownExtra.inc.php`. Each suite prints `✓` / `✗` per assertion plus a tail summary; `run.sh` reports overall pass/fail at the bottom.

## Test plan

- [x] All 12 suites pass on a current Unraid 7.x host with CA installed
- [ ] Reviewer skim of suite contents to confirm coverage matches recently-hardened code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a lightweight dependency-free PHP test harness, orchestration script, README, and many new unit/end-to-end suites to improve reliability.

* **New Features / UI**
  * Full search modal with improved keyboard/grid navigation and global hotkey.
  * Moderation/Statistics sidebar views and Previously Installed listings.
  * Enhanced home/startup displays and infinite-scroll navigation.

* **Improvements**
  * Safer install/update flows, template refresh/force-update handling, and refreshed responsive/mobile layout and theme variables.

* **Removed**
  * Legacy notification banners and the previous settings page UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->