### PR TITLE
Add divider beneath sidebar sticky button row

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -2109,7 +2109,16 @@ input[type="button"] {
 		top: 0;
 		transform: translateX(0);             /* slide into view */
 		opacity: 1;
-
+	}
+	body:has(.sidenavShow) .popupCloseArea::after {
+		content: "";
+		position: absolute;
+		left: 1.5rem;
+		right: 1.5rem;
+		bottom: 2px;
+		height: 1px;
+		background-color: color-mix(in srgb, var(--sidebar-text) 75%, var(--sidebar-background));
+		pointer-events: none;
 	}
 	.popupCloseArea > div:first-child {
 		margin-left: 2rem;


### PR DESCRIPTION
## Summary
- Adds a thin divider line beneath the fixed CLOSE / Settings / Uninstall / Pin row in the sidebar so it visually separates from the scrolling content below.
- Applies in both the app popup and the repo profile sidebar (both share `.popupCloseArea`).
- Implemented as an `::after` pseudo-element on `.popupCloseArea` so existing layout / padding / button placement is untouched.

## Details
- Line is inset 1.5rem from each side (not full-width) and sits 2px above the bottom edge of the sticky area.
- Color is `color-mix(in srgb, var(--sidebar-text) 75%, var(--sidebar-background))` — blends 25% toward the background so the divider reads as ~25% lighter than the font color in every theme (black / gray / azure / white).
- `pointer-events: none` so the divider can't intercept clicks.

## Test plan
- [ ] Open an app card → sidebar opens → divider sits below the sticky button row, inset on both sides.
- [ ] Click a repo name → repo profile sidebar opens → divider also appears there.
- [ ] Switch between black / gray / azure / white themes → divider color tracks the theme and stays subtle.
- [ ] Scroll the sidebar content → divider stays anchored to the sticky button row, doesn't scroll with content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a visual divider line to the sidebar popup close area that displays when the sidebar navigation is visible, improving visual separation and layout clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->