### PR TITLE
chore: ignore .claude/ (Claude Code local state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Temporary Items
 # `user@hostname` for the Unraid box you push test builds to. Never tracked
 # so the hostname / Tailscale name doesn't leak into the repo or clones.
 .unraid-host
+
+# Claude Code local state (subagent worktrees, session metadata).
+.claude/


### PR DESCRIPTION
## Summary
- Claude Code writes session metadata and isolated subagent worktrees to `.claude/` inside any repo it operates from
- None of that should land in this tree, but `gh` will keep warning about it (and a careless `git add .` would commit it)
- One-line addition to [.gitignore](.gitignore)

## Test plan
- [ ] `git status` in a fresh clone after running Claude Code shows no `.claude/` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude local development files from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->