### PR TITLE
chore: add plugins/CHANGES.md for next-release bullets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,67 @@
+# Community Applications — Pending Changes
+
+Running log of changes destined for the next release. Each PR appends its
+user-visible bullets under **Unreleased** below.
+
+Format mirrors the `<CHANGES>` block in [community.applications.plg](plugins/community.applications.plg)
+so release time is a straight copy-paste:
+
+- Keep the `- Added: …` / `- Changed: …` / `- Fixed: …` / `- Removed: …` / `- Chore: …` prefixes.
+- One bullet per change, user-facing wording.
+- Tag any 7.2+-only items explicitly (`7.2+:`).
+
+At release:
+
+1. Replace the `## Unreleased` heading with `###YYYY.MM.DD` (the plg's date format).
+2. Paste that block at the top of `<CHANGES>` in the .plg.
+3. Reset this file to a fresh empty `## Unreleased` section.
+
+This file lives at the repo root and is **not** included in the packaged
+plugin (`pkg_build.sh` only ships `source/community.applications/`).
+
+---
+
+## Unreleased
+
+- Added: Top Nav theme variants (azure and gray) supported in addition to the sidebar themes
+- Added: Search now opens in its own popup window with a dedicated input
+- Added: Browsing and searching use infinite scroll — keep scrolling to load more apps; no more page-number clicks
+- Added: Per-repository ignore list (moderation tool) so entire repositories can be hidden from the catalog
+- Added: Picture and video gallery in the sidebar — left/right arrow keys advance through items
+- Added: Hover the cursor over a video in the gallery and arrow keys go to the player (for seek); hover the area around it and arrow keys navigate between gallery items
+- Changed: Home page now shows 6 apps per section
+- Changed: Settings, Statistics, and Change Log all open inside the sidebar instead of opening as separate pages
+- Changed: Sort controls moved into the search area for quicker access
+- Changed: Pin button keeps a single label and turns green when the app is pinned (matches the Favourite Repo button)
+- Changed: Support links in the sidebar are individual buttons instead of a Support dropdown menu
+- Changed: Action button labels shortened — "Remove from Previous Apps" is now just "Remove"; the multi-select Delete button is now "Remove" too
+- Changed: The multi-select Remove button on Previous Apps now actually appears when entries are checked off
+- Changed: Moderator notes appear above the description; auto-generated configuration warnings appear below it (no header, normal text size, no red border)
+- Changed: Heart and pin icons on the cards now sit inline next to the Details button instead of in the corner of the card
+- Changed: Cards no longer show the speech-bubble icon for moderator/CA comments — those notes appear in the sidebar
+- Changed: Cards no longer show the "Additional Requirements" warning icon — the sidebar still shows the full message and the install flow still blocks updates when required files are missing
+- Changed: Plugin and language-pack cards labelled "Unraid Official" (when appropriate) instead of "Official Container"
+- Changed: Mobile menu redone — survives orientation changes and works on older devices
+- Changed: Close button on popups (screenshots / videos) restyled to match the rest of the action buttons
+- Changed: Custom scrollbars throughout
+- Changed: Licence updated to GPL-2.0-or-later
+- Removed: Pagination bar at the bottom of app lists (infinite scroll replaces it)
+- Removed: Support for private repositories
+- Removed: Banner that briefly appeared when toggling a Favourite Repo (it was hidden behind the sidebar dim overlay anyway)
+- Removed: Action Centre banner alert (the menu indicator already signals pending updates)
+- Fixed: Action Centre would sometimes never load templates; pending updates now show reliably
+- Fixed: Picture/video popup: arrow keys no longer restart a playing video when there is only one item in the gallery
+- Fixed: Popups with a broken image now fall back to the standard "?" placeholder instead of staying blank
+- Fixed: Repository sidebar opened from a card now shows a close button
+- Fixed: Repository sidebar no longer remembers the previously opened app
+- Fixed: Cmd-K / Ctrl-K search shortcut now behaves correctly after the sidebar has been opened
+- Fixed: Clicking a multi-install checkbox no longer opens the sidebar
+- Fixed: Repository sometimes wouldn't open when clicked from a repository card
+- Fixed: Repositories page sometimes appeared as a single column
+- Fixed: Apps-per-page would reset incorrectly after an empty search and during state restore
+- Fixed: Switching between Docker Hub search and regular search wasn't always consistent
+- Fixed: Clearing the search from the popup didn't return to the home page
+- Fixed: Menu state could break across orientation changes
+- Fixed: PHP 8.0+: curl_close warnings in the system log
+- Fixed: Plugin warning is now combined with the initial CYA agreement; previous-app installs are not offered until CYA is accepted
+- Fixed: Debugging tools weren't reporting which files were being read

--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -3,7 +3,7 @@
 Running log of changes destined for the next release. Each PR appends its
 user-visible bullets under **Unreleased** below.
 
-Format mirrors the `<CHANGES>` block in [community.applications.plg](plugins/community.applications.plg)
+Format mirrors the `<CHANGES>` block in [community.applications.plg](community.applications.plg)
 so release time is a straight copy-paste:
 
 - Keep the `- Added: …` / `- Changed: …` / `- Fixed: …` / `- Removed: …` / `- Chore: …` prefixes.
@@ -16,8 +16,8 @@ At release:
 2. Paste that block at the top of `<CHANGES>` in the .plg.
 3. Reset this file to a fresh empty `## Unreleased` section.
 
-This file lives at the repo root and is **not** included in the packaged
-plugin (`pkg_build.sh` only ships `source/community.applications/`).
+This file lives in `plugins/` next to the .plg and is **not** included in
+the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`).
 
 ---
 


### PR DESCRIPTION
## Summary
Introduces `plugins/CHANGES.md` as the running log of user-visible changes destined for the next release. PRs append bullets to a single `## Unreleased` section. At release time the block is copy-pasted into the `<CHANGES>` tag of `plugins/community.applications.plg` (sitting right next to it), then this file is reset to an empty `## Unreleased` shell.

Supersedes the placeholder-block approach in [#27](https://github.com/unraid/community.applications/pull/27): instead of every change PR editing the release .plg (or a shared `###RELEASE_DATE_PLACEHOLDER` block in it), each PR edits this independent file. The .plg only changes at release time.

## Why
- Decouples change-PRs from release-PRs — no merge conflicts on the .plg's placeholder block when multiple PRs are in flight.
- Single source of truth for "what's pending" without rewriting the .plg until release.
- Lives in `plugins/` next to the .plg, **outside** `source/`, so it is **not** packaged: `pkg_build.sh` only ships `source/community.applications/`.

## What's in this PR
- New `plugins/CHANGES.md` with usage instructions at the top.
- `## Unreleased` seeded with the bullets that were proposed in [#27](https://github.com/unraid/community.applications/pull/27) for the Refactoring-branch release, so none of that wording is lost.

## What's NOT in this PR
- No edits to `plugins/community.applications.plg`. PR #27 still carries its `<!ENTITY launch>` removal independently and can be rebased to drop the placeholder block at the maintainer's convenience.

## Test plan
- [ ] Confirm `pkg_build.sh` output `.txz` does not contain `plugins/CHANGES.md` (it shouldn't — staging is only `$ROOT/source/community.applications/`).
- [ ] Sanity-read the seeded Unreleased section for any wording you'd want to tweak before the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pending changes log containing unreleased features and improvements.

* **Chores**
  * Added release documentation structure with packaging and versioning guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->