### PR TITLE
chore: add PR template requiring a CHANGES.md bullet on every PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--
+Thanks for the PR. Please fill out the sections below.
+This template is required — do not delete it.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? Keep it short. -->
+
+## CHANGES.md — required
+
+**Every PR must add at least one bullet to `## Unreleased` in
+[plugins/CHANGES.md](../plugins/CHANGES.md). No exceptions.**
+
+Use one of the standard prefixes — `Added:` / `Changed:` / `Fixed:` /
+`Removed:` / `Chore:` — and write the bullet for the *end user*, in plain
+English. Wording should be the literal copy-paste that will land in the
+plg's `<CHANGES>` block at release time.
+
+If the change is genuinely invisible to end users (build tooling, internal
+refactor, test-only, comment fix), still add a `Chore:` line so the
+release notes show *something* shipped in this PR.
+
+- [ ] I've added a bullet to `plugins/CHANGES.md` under `## Unreleased`.
+
+## Test plan
+
+<!-- Bulleted checklist of what you (or a reviewer) should do to verify
+     this PR. Be specific — paths to click, files to check, edge cases. -->
+
+- [ ] …

--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -1,14 +1,15 @@
 # Community Applications — Pending Changes
 
-Running log of changes destined for the next release. Each PR appends its
-user-visible bullets under **Unreleased** below.
+Running log of changes destined for the next release. **Every PR adds at
+least one bullet to the Unreleased section — no exceptions.**
 
 Format mirrors the `<CHANGES>` block in [community.applications.plg](community.applications.plg)
 so release time is a straight copy-paste:
 
-- Keep the `- Added: …` / `- Changed: …` / `- Fixed: …` / `- Removed: …` / `- Chore: …` prefixes.
-- One bullet per change, user-facing wording.
-- Tag any 7.2+-only items explicitly (`7.2+:`).
+- Use one of the standard prefixes — `Added:` / `Changed:` / `Fixed:` / `Removed:` / `Chore:`.
+- One bullet per change, end-user wording (this text ships verbatim in the next release).
+- If a PR has no user-visible effect (build tooling, internal refactor, test-only), still add a `Chore:` line so the release notes reflect that something shipped.
+- Tag 7.2+-only items explicitly (`7.2+:`).
 
 At release:
 
@@ -65,3 +66,4 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 - Fixed: PHP 8.0+: curl_close warnings in the system log
 - Fixed: Plugin warning is now combined with the initial CYA agreement; previous-app installs are not offered until CYA is accepted
 - Fixed: Debugging tools weren't reporting which files were being read
+- Chore: PR template now prompts contributors to add a CHANGES.md bullet — every PR contributes to the next release notes


### PR DESCRIPTION
## Summary
Adds [`.github/pull_request_template.md`](.github/pull_request_template.md) so GitHub auto-fills the body of every new PR with a scaffold that includes a **required** `CHANGES.md` section. Also tightens the header on [`plugins/CHANGES.md`](plugins/CHANGES.md) to match.

## CHANGES.md — required

The new rule is: every PR (including this one) adds at least one bullet to `## Unreleased`. `Chore:` is the explicit fallback for build / refactor / test-only PRs that have no user-visible effect.

- [x] I've added a bullet to `plugins/CHANGES.md` under `## Unreleased` (`Chore:` line covering this PR).

## What this does
- New PR template visible to every contributor at PR creation — they can't open a PR without seeing the rule.
- CHANGES.md header updated from *"each PR appends its user-visible bullets"* to *"every PR adds at least one bullet — no exceptions"*, with `Chore:` documented as the catch-all for invisible changes.

## What this does NOT do
- No CI enforcement (yet). A reviewer can still approve a PR that ignores the template. If you want a hard gate, the next step is a tiny GitHub Action that fails when `plugins/CHANGES.md` isn't touched in the diff — say the word and I'll wire it up as a follow-on.

## Test plan
- [ ] After merge: open a draft PR against this repo from any branch and confirm the body is auto-populated with the new template.
- [ ] Read the wording — happy to tweak tone / strictness before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contribution documentation and pull request templates to enhance the development workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->