### PR TITLE
chore(plg): drop unused launch entity

### DIFF
--- a/plugins/community.applications.plg
+++ b/plugins/community.applications.plg
@@ -4,13 +4,12 @@
 <!ENTITY author    "Lime Technology">
 <!ENTITY version   "2026.05.15gh">
 <!ENTITY md5       "9cb53f0f77e43e7a0d6b6109efc552b1">
-<!ENTITY launch    "Apps">
 <!ENTITY plugdir   "/usr/local/emhttp/plugins/&name;">
 <!ENTITY github    "unraid/community.applications">
 <!ENTITY pluginURL "https://raw.githubusercontent.com/&github;/master/plugins/&name;.plg">
 ]>
 
-<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.12.0" support="https://forums.unraid.net/topic/38582-plug-in-community-applications" icon="users">
+<PLUGIN name="&name;" author="&author;" version="&version;" pluginURL="&pluginURL;" min="6.12.0" support="https://forums.unraid.net/topic/38582-plug-in-community-applications" icon="users">
 
 <CHANGES>
 ###2026.05.15


### PR DESCRIPTION
## Summary
Removes the `<!ENTITY launch "Apps">` declaration and the matching `launch="&launch;"` attribute on the `<PLUGIN>` tag in [plugins/community.applications.plg](plugins/community.applications.plg). CA's Settings menu opens directly in the sidebar now, so the launch-entity indirection has been dead for a while.

Was originally bundled in [#27](https://github.com/unraid/community.applications/pull/27); splitting it out as its own micro-PR so it lands without waiting on the broader release-notes work in that branch.

## Why no CHANGES.md bullet
Pure .plg cleanup. No source change, no user-visible behaviour change — the plugin already behaves this way at runtime.

## Test plan
- [ ] Build & install the plg on a test box (`pkg_build.sh` + `install_pkg.sh`) — confirm the Apps menu still works and Settings still opens in the sidebar.
- [ ] No regression in plugin auto-update behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 2026.05.15gh with new checksums
  * Simplified plugin configuration by removing unused launch parameter

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->