### PR TITLE
chore: normalize perms to 0755 in copy_to_git and push_live

### DIFF
--- a/copy_to_git.sh
+++ b/copy_to_git.sh
@@ -58,5 +58,15 @@ cd "$LOCAL_DST"
 rm -f ca.md5
 find . -type f -exec md5 -r {} + | awk '{h=$1; $1=""; sub(/^ /, ""); print h"  "$0}' > ca.md5
 
+# Force every file + directory to 0755 — done AFTER the ca.md5 regen so the
+# new ca.md5 itself is included (otherwise the redirect-created file inherits
+# umask and lands at 0644). Slackware tradition (pkg_build does the same on
+# its staging dir) AND keeps git-tracked modes consistent: git stores only
+# the executable bit (100644 vs 100755), so without this the tree drifts
+# between 0644 / 0755 depending on whoever last edited a file locally (Mac
+# umask) vs over ssh (root umask), producing noisy permission diffs on PRs.
+echo "==> Normalizing permissions to 0755"
+chmod -R 0755 "$LOCAL_DST"
+
 echo "==> Done. Source tree updated at:"
 echo "    $LOCAL_DST"

--- a/push_live.sh
+++ b/push_live.sh
@@ -52,7 +52,17 @@ fi
 # No args -> full sync of the entire plugin dir.
 if [ "$#" -eq 0 ]; then
 	echo "==> Full sync  source$LIVE_PREFIX/  ->  $UNRAID_HOST:$LIVE_PREFIX/"
+	# Normalize local perms before sending so the on-disk git tree and the
+	# live install both end up at 0755. Keeps `git status` / future PR diffs
+	# free of permission-only noise.
+	chmod -R 0755 "$SOURCE_ROOT$LIVE_PREFIX"
 	scp -rq "$SOURCE_ROOT$LIVE_PREFIX/." "$UNRAID_HOST:$LIVE_PREFIX/"
+	# Mirror the chmod on the remote too — belt-and-braces against scp/umask
+	# combinations that don't carry the source mode across.
+	ssh "$UNRAID_HOST" sh -s -- "$LIVE_PREFIX" <<-'EOF'
+		set -e
+		chmod -R 0755 "$1"
+	EOF
 	echo "==> Done."
 	exit 0
 fi
@@ -73,7 +83,12 @@ for arg in "$@"; do
 		exit 1
 	fi
 	remote="/$rel"
+	# Force 0755 on the local path before sending — keeps the git tree and
+	# the live install consistent at 0755 so future copy_to_git / PR diffs
+	# don't surface permission-only churn. Recursive for dirs, single chmod
+	# for files.
 	if [ -d "$abs" ]; then
+		chmod -R 0755 "$abs"
 		echo "==> $arg/  ->  $UNRAID_HOST:$remote/"
 		# Trailing /. on src + trailing / on dst copies *contents* of the
 		# directory into the existing remote directory.
@@ -83,13 +98,23 @@ for arg in "$@"; do
 			mkdir -p "$1"
 		EOF
 		scp -rq "$abs/." "$UNRAID_HOST:$remote/"
+		# Mirror the chmod remotely.
+		ssh "$UNRAID_HOST" sh -s -- "$remote" <<-'EOF'
+			set -e
+			chmod -R 0755 "$1"
+		EOF
 	else
+		chmod 0755 "$abs"
 		echo "==> $arg  ->  $UNRAID_HOST:$remote"
 		ssh "$UNRAID_HOST" sh -s -- "$(dirname "$remote")" <<-'EOF'
 			set -e
 			mkdir -p "$1"
 		EOF
 		scp -q "$abs" "$UNRAID_HOST:$remote"
+		ssh "$UNRAID_HOST" sh -s -- "$remote" <<-'EOF'
+			set -e
+			chmod 0755 "$1"
+		EOF
 	fi
 done
 


### PR DESCRIPTION
## Summary

A lot of recent PRs (especially when files have been hand-edited live vs over ssh, then sync'd in via `copy_to_git`) end up shipping permission-only diffs on otherwise-untouched files. Git tracks only the executable bit (100644 vs 100755), so the tree drifts whenever umask varies between editors.

`pkg_build.sh` already forces 0755 on its staging dir before `tar -cJf`. This PR extends the same treatment to the two scripts that move files between the live install and `source/`:

- **`copy_to_git.sh`** — after the scrub (`.DS_Store` / `._*` / `.claude`), before regenerating `ca.md5`: `chmod -R 0755 "$LOCAL_DST"`. Anything pulled from live lands at 0755 in git.
- **`push_live.sh`** — before each scp (both the no-args full sync and the per-path mode): chmod 0755 locally + matching remote chmod after. Belt-and-braces against scp/umask combinations that don't carry source mode through.

`claude_build.sh` calls `copy_to_git` + `pkg_build`, both of which now end at 0755 — no direct change needed there.

## Test plan

- [ ] Run `./copy_to_git.sh` against the current live install → resulting `source/` tree is all 0755 (`find source -type f -perm -u+x | wc -l` matches `find source -type f | wc -l`).
- [ ] Run `./push_live.sh` (full sync) → live install files end up 0755 on the Unraid box (`ssh root@host 'find /usr/local/emhttp/plugins/community.applications -type f \! -perm -0755'` returns no rows).
- [ ] Run `./push_live.sh source/.../include/exec.php` → that single file is 0755 both locally and remotely.
- [ ] Subsequent `git status` after a copy_to_git round trip on an unchanged live install shows no permission-only churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission inconsistencies during deployments that caused noisy diffs and transfer issues across different environments.
  * Ensured remote live trees match local permission state after syncs.

* **Chores**
  * Normalized file and directory permissions before and after synchronization to keep executable bits consistent.
  * Added logging around permission normalization to improve traceability during deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->