### PR TITLE
chore: wipe remote plugin dir before full push_live sync

### DIFF
--- a/push_live.sh
+++ b/push_live.sh
@@ -56,6 +56,21 @@ if [ "$#" -eq 0 ]; then
 	# live install both end up at 0755. Keeps `git status` / future PR diffs
 	# free of permission-only noise.
 	chmod -R 0755 "$SOURCE_ROOT$LIVE_PREFIX"
+	# Wipe the remote install dir first so files that existed in a previous
+	# version but no longer exist in source/ don't linger (scp only writes
+	# what's in the source — it doesn't prune the destination). Safety-gate
+	# the rm to paths under /usr/local/emhttp/plugins/ in case LIVE_PREFIX
+	# ever gets mis-set, so a typo can't `rm -rf /` the box.
+	echo "==> Wiping remote $LIVE_PREFIX (clears stragglers from prior versions)"
+	ssh "$UNRAID_HOST" sh -s -- "$LIVE_PREFIX" <<-'EOF'
+		set -e
+		case "$1" in
+			/usr/local/emhttp/plugins/*) ;;
+			*) echo "Refusing to rm -rf $1 — not under /usr/local/emhttp/plugins/" >&2; exit 1 ;;
+		esac
+		rm -rf "$1"
+		mkdir -p "$1"
+	EOF
 	scp -rq "$SOURCE_ROOT$LIVE_PREFIX/." "$UNRAID_HOST:$LIVE_PREFIX/"
 	# Mirror the chmod on the remote too — belt-and-braces against scp/umask
 	# combinations that don't carry the source mode across.


### PR DESCRIPTION
## Summary

`scp -rq` only writes the source files to the destination — it never prunes. So a file that lived in the plugin dir in a previous version but no longer exists in `source/` keeps lingering on the box after a `push_live.sh` full sync, which can mask staleness bugs or confuse the next `copy_to_git` pull (it scoops up the stale file back into the git tree).

For the **no-args full-sync** path only, ssh in first and:
1. `rm -rf "$LIVE_PREFIX"` to wipe the install dir.
2. `mkdir -p "$LIVE_PREFIX"` to recreate it.
3. Then the existing scp + remote chmod.

Per-path mode (`./push_live.sh source/.../some/file`) is **untouched** — wouldn't want a single-file push nuking the whole install.

### Safety gate

The rm is gated by a `case "$1" in /usr/local/emhttp/plugins/*) ;; *) … exit 1 ;;` match against the path passed over ssh. If `LIVE_PREFIX` ever gets mis-set (typo, bad env, etc.), the remote refuses to run rather than recursing somewhere dangerous.

## Test plan

- [ ] Touch a junk file in the live install (`ssh root@host 'touch /usr/local/emhttp/plugins/community.applications/junk.txt'`).
- [ ] Run `./push_live.sh` (no args, full sync).
- [ ] Confirm `junk.txt` is gone afterwards.
- [ ] Run `./push_live.sh source/.../include/exec.php` (single file).
- [ ] Confirm the live install dir is still populated — per-path mode didn't wipe anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Full synchronization now automatically clears the remote destination directory before uploading files, preventing conflicts from outdated versions. Built-in safety restrictions ensure cleanup only affects designated system paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->