### PR TITLE
fix: restore Support menu link styling

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/ca.md5
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/ca.md5
@@ -36,7 +36,7 @@ d2cce47ea7c6627277201239dda3f0a2  ./javascript/helpers.js
 158bd1f80bd4a1677f1b5758c99ab0e4  ./javascript/diff.js
 39c8d4d32141744a859eedb89960a0ca  ./javascript/clickHandlers.js
 3d0aab17bf29c784d9d56ff04512eb95  ./skins/Narrow/skin_helpers.php
-79298b88aacc608565d336f9d12eb5a9  ./skins/Narrow/skin.html
+fa628b69b8ba130e9efcbad72aee5ae3  ./skins/Narrow/skin.html
 58e39da29cd6a1452499a02bcc8ddecb  ./skins/Narrow/skin.php
 213e64078b3f9450a520d2b06cc3cd1f  ./skins/Narrow/styles/community.applications.responsive.css
 55ed9d68a3cda4e37dd58055b594eb67  ./skins/Narrow/styles/community.applications.css

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
@@ -183,7 +183,7 @@ $(function() {
 				<li class='caMenuItem showSettings noSelect'><?tr("Settings");?></li>
 				<li class='caMenuItem showStatistics noSelect'><?tr("Statistics");?></li>
 				<li class='caMenuItem showCredits noSelect'><?tr("Credits");?></li>
-				<li class='caMenuItem noSelect'><a href='https://forums.unraid.net/topic/38582-plug-in-community-applications/' target='_blank' rel='noopener noreferrer'><?tr("Support");?></a></li>
+				<li class='caMenuItem noSelect'><a class='caMenuItem' href='https://forums.unraid.net/topic/38582-plug-in-community-applications/' target='_blank' rel='noopener noreferrer'><?tr("Support");?></a></li>
 				<li><hr class='category_hr'/></li>
 				<li><?=tr("VERSION");?></li>
 				<li><span id='caInstalledVersion'></span></li>


### PR DESCRIPTION
## Summary
- The Support entry in the sidebar menu lost the `caMenuItem` class on its `<a>` during a prior li/ul rearrange, so the link rendered with default browser styling (blue, underlined) instead of inheriting the sidebar text colour like every other menu item.
- Re-add `class='caMenuItem'` on the anchor so the existing `a.caMenuItem { color: inherit; text-decoration: none; }` rule applies.

## Test plan
- [ ] Sidebar Support entry renders in the same colour as Settings / Statistics / Credits, no underline; click still opens the forum thread in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved styling consistency for the "Support" link in the mobile menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->