### PR TITLE
refactor: mobile responsive tweaks + sidebar trim

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -79,3 +79,6 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 - Fixed: Security and reliability hardening — unsafe links stripped from rendered README and changelog content, template URLs validated before fetching, backend input handling tightened
 - Fixed: Plugin-install dialog after a mixed Docker + plugin multi-install no longer opens parked behind the main display
 - Fixed: A feed update from another browser session while an install dialog is open now waits until the install finishes before showing the reload notice
+- Changed: Mobile layout pass — sidebar README, trend charts, and floating scroll buttons hide on phone-sized viewports; menu strip alignment and chrome positions tightened across nav-top and sidebar themes
+- Changed: Opening the mobile menu now scrolls the menu back to the top instead of leaving it wherever it was last
+- Removed: "All statistics are only gathered every 30 days" note from the sidebar

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -2342,6 +2342,9 @@ function showSettings() {
  */
 function showMenu() {
 	$(".menuAdjust,.hideWithMenu,.mobileMenu").addClass("menuShowing").removeClass("menuHidden");
+	/* Snap the menu scroll back to the top each time it opens — wherever the
+	   user left it (after a long category list, etc.) shouldn't carry over. */
+	$(".menuItems").scrollTop(0);
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -423,10 +423,6 @@ function displayPopup($template) {
 		}
 	}
 
-	$statsNote = "";
-	if (! $Plugin && ! $Language) {
-		$statsNote = "<div class='popupStatsNote'><br><span class='ca_note ca_bold'><span class='ca_fa-asterisk'></span> ".tr("Note: All statistics are only gathered every 30 days")."</span></div>";
-	}
 	$readmeSection = caBuildReadmeSectionDiv($template);
 	$readmeButton = "";
 	if ($readmeSection === "" && !empty($template['ReadMe']) && validURL($template['ReadMe'])) {
@@ -478,10 +474,16 @@ function displayPopup($template) {
 					<?php if (!empty($supportContext)): ?>
 						<div class='popupSupportRow'>
 							<?php foreach ($supportContext as $sc): ?>
+								<?php
+								/* Optional caller-supplied extra class (e.g. ca_devMode for
+								   dev-mode-only buttons) — appended to the static caButton +
+								   supportPopup pair so responsive CSS can target it. */
+								$scExtraClass = !empty($sc['class']) ? " ".htmlspecialchars($sc['class'], ENT_QUOTES) : "";
+								?>
 								<?php if (!empty($sc['action'])): ?>
-									<div class='caButton supportPopup' onclick="<?= htmlspecialchars($sc['action'], ENT_QUOTES) ?>"><span class='<?= $sc['icon'] ?>'> <?= $sc['text'] ?></span></div>
+									<div class='caButton supportPopup<?= $scExtraClass ?>' onclick="<?= htmlspecialchars($sc['action'], ENT_QUOTES) ?>"><span class='<?= $sc['icon'] ?>'> <?= $sc['text'] ?></span></div>
 								<?php elseif (validURL($sc['link'] ?? "")): ?>
-									<div class='caButton supportPopup'><a href='<?= htmlspecialchars($sc['link'], ENT_QUOTES) ?>' target='_blank'><span class='<?= $sc['icon'] ?>'> <?= $sc['text'] ?></span></a></div>
+									<div class='caButton supportPopup<?= $scExtraClass ?>'><a href='<?= htmlspecialchars($sc['link'], ENT_QUOTES) ?>' target='_blank'><span class='<?= $sc['icon'] ?>'> <?= $sc['text'] ?></span></a></div>
 								<?php endif; ?>
 							<?php endforeach; ?>
 						</div>
@@ -546,7 +548,6 @@ function displayPopup($template) {
 					</div>
 				</div>
 			</div>
-			<?= $statsNote ?>
 			<?= $changeLogBlock ?>
 			<?= $moderationBlock ?>
 		</div>

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -275,9 +275,13 @@ function caBuildSupportContext(array $template, array $allRepositories) {
 		$supportContext[] = ["icon"=>"ca_fa-docker","link"=>$template['Registry'],"text"=>tr("Registry")];
 	}
 	if ($GLOBALS['caSettings']['dev'] == "yes") {
-		$supportContext[] = ["icon"=>"ca_fa-template","link"=>$template['caTemplateURL'] ?: ($template['TemplateURL'] ?? ""), "text"=>tr("Template")];
+		/* Every entry below is dev-mode only. The `class` is read by the
+		   sidebar template (skin.php → displayPopup) and rendered onto the
+		   caButton so responsive CSS can hide them on phone-sized viewports
+		   (.ca_devMode { display: none } under 767px). */
+		$supportContext[] = ["icon"=>"ca_fa-template","link"=>$template['caTemplateURL'] ?: ($template['TemplateURL'] ?? ""), "text"=>tr("Template"), "class"=>"ca_devMode"];
 		if (!empty($template['Plugin']) && !empty($template['PluginURL'])) {
-			$supportContext[] = ["icon"=>"ca_fa-template","link"=>$template['PluginURL'],"text"=>tr("Plugin")];
+			$supportContext[] = ["icon"=>"ca_fa-template","link"=>$template['PluginURL'],"text"=>tr("Plugin"), "class"=>"ca_devMode"];
 		}
 		/* json_encode with the JS-safety flags produces a properly-quoted JS
 		   string literal (including the outer quotes) — safer than addslashes
@@ -294,6 +298,7 @@ function caBuildSupportContext(array $template, array $allRepositories) {
 				"icon"   => "ca_fa-diff",
 				"action" => "caShowTemplateDiff({$diffPath},{$diffName},'feed')",
 				"text"   => tr("Diff"),
+				"class"  => "ca_devMode",
 			];
 		}
 		/* Internal diff (appfeed vs CA's internal templates_full.json) — only
@@ -304,6 +309,7 @@ function caBuildSupportContext(array $template, array $allRepositories) {
 				"icon"   => "ca_fa-diff",
 				"action" => "caShowTemplateDiff({$diffPath},{$diffName},'internal')",
 				"text"   => tr("CA"),
+				"class"  => "ca_devMode",
 			];
 		}
 	}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -1894,11 +1894,10 @@ body,
 		margin-top: 1.5rem;
 		font-size: 2.5rem;
 	}
-	/* Align the trends/charts area, stats-note line, changelog block, and
-	   moderation/template-errors block with the other indented popup content
-	   blocks (popupDescription / popupTable etc.). */
+	/* Align the trends/charts area, changelog block, and moderation/template-
+	   errors block with the other indented popup content blocks
+	   (popupDescription / popupTable etc.). */
 	.popupChartBlock,
-	.popupStatsNote,
 	.popupChangeLogBlock,
 	.popupModerationBlock {
 		margin-left: 1rem;
@@ -3372,10 +3371,13 @@ input[type="button"] {
 		opacity: 0.65;
 		margin: 0;
 		top: 50%;
-		margin-top: -55px;
+		/* Box just big enough to hold the existing triangle visuals at their
+		   original positions — was 90×110px which made the hover brighten
+		   feel huge. Triangle margins below are unchanged. */
+		margin-top: -40px;
 		padding: 0;
-		width: 90px;
-		height: 110px;
+		width: 70px;
+		height: 80px;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
@@ -22,7 +22,9 @@
 		padding-left: 2rem;
 	}
 	.Theme--sidebar .searchAreaHolder {
-		margin-left: 6rem;
+		margin-left: 5rem;
+		left: 0;
+		width: 16rem;
 	}
 	.searchArea {
 		padding-left: 0;
@@ -36,6 +38,33 @@
 	}
 	#ca_mobile_layout_probe {
 		left: 0;
+	}
+
+	/* MagnificPopup gallery arrows + close button: on touch (tablet- and
+	   phone-sized viewports) the focus/active state sticks after a tap,
+	   painting the right arrow with a full unraid-orange backdrop (browser
+	   button focus rendering bleeds through despite
+	   `-webkit-tap-highlight-color: transparent`) and the close X in orange.
+	   Pin every interactive state back to the default look so a tap never
+	   leaves them lit. !important needed because the desktop close rule is
+	   also marked important. */
+	.mfp-arrow:hover,
+	.mfp-arrow:focus,
+	.mfp-arrow:focus-visible,
+	.mfp-arrow:active {
+		opacity: 0.65;
+		background: transparent !important;
+		outline: none !important;
+		box-shadow: none !important;
+	}
+	.mfp-close:hover,
+	.mfp-close:focus,
+	.mfp-close:focus-visible,
+	.mfp-close:active {
+		color: inherit !important;
+		background: transparent !important;
+		outline: none !important;
+		box-shadow: none !important;
 	}
 }
 @media (max-width: 767px) {
@@ -55,11 +84,24 @@
 	#footer {
 		display: none;
 	}
+	/* Footer is gone on mobile — let the sidebar reach the viewport edge
+	   instead of reserving room for it. */
+	.sidenav {
+		bottom: 0;
+		margin-bottom: 0;
+	}
 	#header {
 		display: none;
 	}
 	.searchAreaHolder {
 		top: var(--search-area-mobile-top);
+	}
+	.Theme--nav-top .searchAreaHolder {
+		padding-left: 0;
+	}
+	/* Nav-top: narrow the search bar to make room for the open menu strip. */
+	.Theme--nav-top .searchAreaHolder.menuShowing {
+		width: 17rem;
 	}
 	.Theme--nav-top .ca_display_area {
 		top: 11rem;
@@ -77,8 +119,13 @@
 
 	:root {
 		/* Mobile slide-in menu width — referenced by the scrim offset below
-		   so the two stay in lockstep. */
-		--ca-mobile-menu-width: 20rem;
+		   so the two stay in lockstep. Default is 0rem; sidebar-style themes
+		   (azure / gray, tagged Theme--sidebar on body by Apps.page) override
+		   below to reveal an inline menu strip. */
+		--ca-mobile-menu-width: 0rem;
+	}
+	.Theme--sidebar {
+		--ca-mobile-menu-width: 23rem;
 	}
 	.mobileMenu.menuHidden{
 		display: none;
@@ -97,10 +144,25 @@
 		top: 2rem;
 	}
 	.Theme--nav-top .menuItems {
-		top: 11rem;
+		top: 10.5rem;
+		bottom: 0;
+	}
+	/* Nav-top mobile menu strip: flush left, small inner padding. */
+	.Theme--nav-top .menuItems.menuShowing {
+		left: 0;
+		padding-left: 1rem;
 	}
 	.Theme--sidebar .menuItems {
 		top: 2.5rem;
+		bottom: 0;
+	}
+	/* Sidebar themes — pull the inline menu strip flush against the rail when
+	   the mobile menu is showing. */
+	.Theme--sidebar .menuItems.menuShowing {
+		margin-left: -1rem;
+	}
+	.Theme--sidebar .mainArea {
+		top: 3rem;
 	}
 	.Theme--sidebar .ca_display_area {
 		top: 1rem;
@@ -126,6 +188,26 @@
 	#templates_content {
 		margin-bottom: 0;
 	}
+
+	/* Mobile real estate is too cramped for the floating scroll controls —
+	   they overlap cards and the search/menu chrome. Hide for all themes
+	   (rule wins over the desktop visibility defaults; the body-level pair
+	   AND the in-sidenav pair both match). */
+	.ca_back_to_top,
+	.ca_move_to_end {
+		display: none !important;
+	}
+
+	/* README on the sidebar is bulky on a phone-sized viewport — link in the
+	   popup body still points to the project's README on the web. Dev-mode
+	   buttons (Template / Plugin / Diff / CA) also hide — too much real
+	   estate next to the user-facing Support buttons. */
+	.ReadmeSection,
+	.popupChartBlock,
+	.ca_devMode {
+		display: none;
+	}
+
 }
 @media (max-height: 600px) {
 	#header {
@@ -134,11 +216,12 @@
 
 	.Theme--nav-top .ca_display_area {
 		top: 11rem;
+		bottom: 0;
 	}
 	.menuItems {
 		top: 2rem;
 	}
 	.Theme--nav-top .menuItems {
-		top: 12rem;
+		top: 10.5rem;
 	}
 }


### PR DESCRIPTION
## Summary

### Responsive tweaks
- **<1024px** — `.Theme--sidebar .searchAreaHolder`: `margin-left` 5rem (was 6rem), `left: 0`, `width: 16rem` so the search bar fits the sidebar rail.
- **<767px** — `--ca-mobile-menu-width` defaults to `0rem` (collapsed) and bumps to `23rem` on `Theme--sidebar` so azure/gray reveal an inline menu strip while black/white stay collapsed.
- **<767px sidebar themes** — `.menuItems` gains `bottom: 0`; `.menuItems.menuShowing` pulls `margin-left: -1rem` flush against the rail; `.mainArea` pinned at `top: 3rem`.
- **<767px nav-top themes** — `.menuItems` top: `10.5rem` (was 11rem), `bottom: 0`; `.menuItems.menuShowing` gets `left: 0` / `padding-left: 1rem`. `.searchAreaHolder` gets `padding-left: 0` and a `.menuShowing` `width: 17rem` so it narrows when the menu is open.
- **max-height: 600px** — `.Theme--nav-top .ca_display_area` gains `bottom: 0`; `.Theme--nav-top .menuItems` top tightened 12rem → 10.5rem.
- **<767px all themes** — hide `.ca_back_to_top` / `.ca_move_to_end`, `.ReadmeSection`, and `.popupChartBlock` so the sidebar fits a phone.

### Other
- `showMenu()` scrolls `.menuItems` back to the top each time the mobile menu opens.
- Drop the "All statistics are only gathered every 30 days" note from the sidebar entirely; `.popupStatsNote` removed from the alignment rule.

## Test plan
- [ ] Azure & gray under 1024px: search bar fits the rail; under 767px the menu strip opens flush against the rail.
- [ ] Black & white under 767px: search bar narrows to 17rem when the menu opens; menu strip aligns flush left with 1rem inner padding.
- [ ] Under 767px, all themes: README section, charts, and back-to-top/move-to-end buttons gone from the sidebar.
- [ ] Tap the mobile menu button on a long page — menu scrolls to top instead of opening mid-list.
- [ ] Sidebar on any docker app no longer shows the "All statistics gathered every 30 days" line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile menu now resets its scroll position when opened
  * Removed outdated note about statistics collection frequency

* **UI/UX Improvements**
  * Improved mobile responsiveness, spacing, and popup alignment for small viewports
  * Sidebar README, trend charts, and floating scroll controls hidden on phone-sized screens
  * Refined mobile menu sizing, placement, and nav alignment; dev-mode actions hidden on small screens

* **Documentation**
  * Added unreleased changelog entries describing these mobile/layout updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->