### PR TITLE
fix: skip rewriting plugin attribute cache on a pure cache hit

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -174,6 +174,7 @@ function ca_plugin($method, $plugin_file = '',$dontCache = false) {
 			}
 		}
 		if ( $plugin_file) {
+			$dirty = false;
 			if ( is_file($plugin_file) ) {
 				if ( !isset($attributeCache[$plugin_file]) ) {
 					debug("CA Plugin $method $plugin_file not in attribute cache");
@@ -184,13 +185,17 @@ function ca_plugin($method, $plugin_file = '',$dontCache = false) {
 						$attributes = false;
 					}
 					$attributeCache[$plugin_file] = (array)$attributes ?: ["error" => "no attributes present"];
+					$dirty = true;
 				} else {
 					debug("$plugin_file already in attribute cache");
 				}
-			} else {
+			} else if ( isset($attributeCache[$plugin_file]) ) {
 				unset($attributeCache[$plugin_file]);
+				$dirty = true;
 			}
-			writeJsonFile(CA_PATHS['pluginAttributesCache'], $attributeCache);
+			if ( $dirty ) {
+				writeJsonFile(CA_PATHS['pluginAttributesCache'], $attributeCache);
+			}
 
 			// return the cached result if it exists.  If it doesn't return false;;
 			return $attributeCache[$plugin_file]['@attributes'][$method]??false;


### PR DESCRIPTION
## Summary
- `ca_plugin()` in `include/helpers.php` called `writeJsonFile()` unconditionally before returning, so every cached-hit attribute read serialized the entire attribute cache back to disk even though nothing had changed.
- Added a `$dirty` flag and only persist when the cache was actually mutated: a new XML parse, or a stale entry removed because its `.plg` no longer exists.
- Also guarded the `unset()` branch so a missing-file lookup for a key that isn't in the cache no longer triggers a write.

## Test plan
- [ ] On a system with many installed plugins, exercise an attribute-heavy page (e.g. plugin list/sidebar) and confirm `pluginAttributesCache.json` mtime no longer updates on repeat loads when nothing changed.
- [ ] Install a new plugin → first read should still populate the cache and write to disk.
- [ ] Remove a `.plg` (or pass a path that no longer exists) → cache entry is unset and the file is rewritten on that call only.
- [ ] Trigger one of the `$PLUGIN_METHODS` (e.g. `install`, `remove`) and confirm the attribute cache is still dropped via the existing branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized plugin attribute caching efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->