### PR TITLE
refactor: replace diagonal corner ribbons with horizontal badges

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -2186,7 +2186,7 @@ function updateDisplay(content, append) {
 	if (typeof caUpdateScrollControls === "function") caUpdateScrollControls();
 	enableSearch();
 
-	$(".betaPopupText,.installedCardText,.upgradePopupText,.LTOfficialPopupText").fitText(true);
+	$(".betaPopupText,.upgradePopupText,.LTOfficialPopupText").fitText(true);
 
 	if ( $("html").hasClass("translated-ltr") || $("html").hasClass("translated-rtl") || $("head").hasClass("translated-ltr") || $("head").hasClass("translated-rtl") ) {
 		data.translationBanner = addBannerWarning("<?=tr("Browser translation detected.  Display issues may result");?>");

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
@@ -537,7 +537,7 @@ $(function() {
 	<div class='ca_templatesDisplay' style='visibility:hidden;'>
 		<div>
 			<div class="installedCardBackground">
-				<div class="installedCardText ca_center" style="font-size: 70%;">&nbsp;&nbsp;INSTALLED&nbsp;&nbsp;</div>
+				<div class="installedCardText ca_center">INSTALLED</div>
 			</div>
 			<div
 				class="ca_holder ca_appTemplate ca_appPopup "

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -1125,11 +1125,11 @@ function displayCard($template) {
 	}
 
 	if (!empty($template['Installed']) || !empty($template['Uninstall'])) {
-		$flagTextStart = tr("Installed")."<br>";
+		$flagTextStart = tr("Installed")." · ";
 		$flagTextEnd = "";
 	} else {
-		$flagTextStart = "&nbsp;";
-		$flagTextEnd = "&nbsp;";
+		$flagTextStart = "";
+		$flagTextEnd = "";
 	}
 
 	$cardFlag = caBuildCardFlag($template, $flagTextStart, $flagTextEnd);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -1900,7 +1900,7 @@ function caBuildCardFlag(array $template, string $flagTextStart, string $flagTex
 	if (!empty($template['LTOfficial'])) {
 		return "
 			<div class='LTOfficialCardBackground'>
-				<div class='installedCardText ca_center' title='".tr("This is an official plugin")."'>".tr("LIMETECH")."</div>
+				<div class='installedCardText ca_center' title='".tr("This is an official plugin")."'>".tr("OFFICIAL")."</div>
 			</div>
 		";
 	}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -1851,7 +1851,7 @@ function caBuildCardFlag(array $template, string $flagTextStart, string $flagTex
 	if ((!empty($template['Installed']) || !empty($template['Uninstall'])) && empty($template['actionCentre'])) {
 		return "
 			<div class='installedCardBackground'>
-				<div class='installedCardText ca_center'>&nbsp;&nbsp;".tr("INSTALLED")."&nbsp;&nbsp;</div>
+				<div class='installedCardText ca_center'>".tr("INSTALLED")."</div>
 			</div>";
 	}
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -2186,7 +2186,8 @@ input[type="button"] {
 		background-color: var(--ca-purple-color);
 	}
 	.LTOfficialCardBackground {
-		background-color: var(--ca-orange-color);
+		/* Unraid brand gradient: Red #e22828 → Orange #f15a2c → Gold #ff8c2f */
+		background: linear-gradient(to right, #e22828 0%, #f15a2c 50%, #ff8c2f 100%);
 	}
 	.officialCardBackground,
 	.spotlightCardBackground {

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -2159,7 +2159,7 @@ input[type="button"] {
 		margin-top: 0px;
 	}
 
-	/* 3.11) Corner ribbons, pagination, and popup details */
+	/* 3.11) Corner badges, pagination, and popup details */
 	.officialCardBackground,
 	.LTOfficialCardBackground,
 	.spotlightCardBackground,
@@ -2167,13 +2167,20 @@ input[type="button"] {
 	.betaCardBackground,
 	.greenCardBackground,
 	.installedCardBackground {
-		clip-path: polygon(0 0, 100% 0, 100% 100%);
 		position: absolute;
-		top: 0;
-		right: 0;
-		height: 9rem;
-		width: 9rem;
+		top: 0.75rem;
+		right: 0.75rem;
+		padding: 0.35rem 0.75rem;
+		border-radius: 0.4rem;
+		font-size: 1.1rem;
+		line-height: 1;
+		letter-spacing: 0.05rem;
+		text-transform: uppercase;
+		font-weight: 600;
+		color: var(--ca-named-white);
 		pointer-events: none;
+		z-index: 2;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 	}
 	.installedCardBackground {
 		background-color: var(--ca-purple-color);
@@ -2196,20 +2203,11 @@ input[type="button"] {
 	}
 
 	.installedCardText {
-		position: absolute;
-		transform: rotate(45deg);
-		-webkit-transform: rotate(45deg);
-		-moz-transform: rotate(45deg);
-		-o-transform: rotate(45deg);
-		color: var(--ca-named-white);
-		font-size: 1.1rem;
-		position: absolute;
-		top: 2rem;
-		right: 0rem;
-		width: 6rem;
-		overflow: hidden;
-		height: 2.5rem;
-		display: inline;
+		display: inline-block;
+		color: inherit;
+		font-size: inherit;
+		line-height: inherit;
+		white-space: nowrap;
 	}
 
 	.LTOfficialPopupText {


### PR DESCRIPTION
## Summary
- Card status flags (Official, LimeTech, Beta, Installed, Updated, Template, Blacklisted, Incompatible, Deprecated, Digitally Signed) are no longer diagonal ribbons. They render as horizontal pill-shaped badges in the top-right corner with the same per-status colour coding.
- The CSS drops the `clip-path` triangle and 45° rotation in `community.applications.css` and replaces them with padding/border-radius. `.installedCardText` now flows inline inside the badge.
- `&nbsp;` spacing in `skin.html` and `skin_helpers.php` is removed — CSS padding handles it.
- The combined "Installed + Incompatible/Blacklisted/Deprecated" case used to put `Installed<br>` on top of the status; now it renders inline as `INSTALLED · INCOMPATIBLE` to fit the horizontal badge.
- `.installedCardText` removed from the `fitText` auto-resize selector in `Apps.page` since content-sized badges no longer need it.

## Test plan
- [ ] Visit the Apps page and confirm Official / LimeTech / Beta / Installed / Updated / Template / Trusted badges all render as horizontal pills in the top-right of each card with the right colours.
- [ ] Install a deprecated/incompatible/blacklisted app to verify the combined "Installed · Incompatible" badge reads on one line.
- [ ] Verify badges don't trip click handlers on the card (pointer-events:none preserved).
- [ ] Re-check the existing tooltips (`title` attrs) on Blacklisted/Incompatible/Deprecated/Official/LimeTech/Template/Trusted still appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the "INSTALLED" badge into a pill-style label with rounded corners, shadow, uppercase text and a red→orange→gold gradient for official apps; removed decorative inline sizing/spacing in favor of CSS.
* **Bug Fixes / UI**
  * Improved card text handling so installed-card labels no longer get auto-resized or awkward spacing; banner text now displays cleanly (uses "OFFICIAL" for official apps).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->