### PR TITLE
fix: navigate Home/Clear Search to /Apps instead of reloading

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -1172,9 +1172,12 @@ function caInitializeClickHandlers() {
 	$(".multi_deleteButton").click(function() { deleteMulti(); });
 	$(".multi_installAll").click(function() { selectAllPrevious(); enableMultiInstall(); });
 	/**
-	 * Home/Startup button click: set `data.ignoreUnload` so saveState() does
-	 * not run on the upcoming reload, clear CA-related cookies (with legacy
-	 * cookie option fallbacks), then `window.location.reload()`.
+	 * Home/Startup button click (also the Clear Search variant of this button):
+	 * set `data.ignoreUnload` so saveState() does not run on the upcoming
+	 * navigation, clear CA-related cookies (with legacy cookie option
+	 * fallbacks), then navigate to /Apps. We navigate rather than reload so
+	 * any GET arguments in the current URL (e.g. ?search=, ?category=) are
+	 * dropped — a true "Home" should land on the clean Apps URL.
 	 */
 	$("body").on("click", ".startupButton", function() {
 		/* Home should start fresh; prevent onbeforeunload from writing saveState cookies back. */
@@ -1192,7 +1195,7 @@ function caInitializeClickHandlers() {
 			/* Some legacy calls used a non-standard cookie options string; clear that too just in case. */
 			try { $.removeCookie(name, { path: "/;SameSite=Lax" }); } catch (e2) { /* no-op */ }
 		});
-		window.location.reload();
+		window.location.assign("/Apps");
 	});
 	$(".multi_installButton").click(function() { if ($(".multi_installButton").hasClass("actionCenter")) updateMulti(); else installMulti(); });
 	/**


### PR DESCRIPTION
## Summary
- The `.startupButton` handler doubles as the Home button and the Clear Search button (its label toggles via `caHomeMenuLabel` based on whether a search is active).
- Previously it ran `window.location.reload()`, which preserved any GET arguments in the URL (e.g. `?search=foo`, `?category=Plugins`). The cookies were wiped but the URL was not — so reloading often re-applied state from the query string and the page didn't actually feel "cleared".
- Swap `reload()` for `window.location.assign("/Apps")` so a Home click always lands on the canonical `/Apps` URL with no query string.

## Test plan
- [ ] Open `/Apps?search=qbittorrent` (or similar) → click Clear Search → URL becomes `/Apps`, search box is empty, full grid renders.
- [ ] Click Home with no search active → still lands on `/Apps`, no query args.
- [ ] Trigger `caShowFatalReloadBanner` (or wait for the feed-refresh banner) and click → routes through `.startupButton` → also lands on `/Apps`.
- [ ] CA cookies (`ca_data`, `ca_searchActive`, `ca_installMulti`, `ca_selectedMenu`, `ca_filter`, `ca_categoryName`, `ca_categoryText`) are still cleared before navigating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Home/Startup button navigation to cleanly direct users to the Apps section, clearing any URL parameters from the previous navigation state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->