### PR TITLE
refactor: snapshot raw applicationFeed.json during feed download (dev-mode only) for the Diff button

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/diff.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/diff.php
@@ -82,12 +82,13 @@ function getTemplateDiff() {
 		return;
 	}
 
-	/* Both modes need the appfeed entry — download (or reuse cached) the
-	   applicationFeed.json and locate the matching entry by TemplateURL /
-	   PluginURL. See caGetCachedApplicationFeed for the lock / cache flow. */
+	/* Both modes need the appfeed entry — read the raw snapshot stashed by
+	   DownloadApplicationFeed() when dev mode is on, and locate the matching
+	   entry by TemplateURL / PluginURL. Snapshot is rewritten on every feed
+	   refresh; cold start (dev mode just enabled) returns null. */
 	$applicationFeed = caGetCachedApplicationFeed();
 	if (!is_array($applicationFeed)) {
-		postReturn(["ok"=>false, "message"=>tr("Could not download application feed")]);
+		postReturn(["ok"=>false, "message"=>tr("Application feed snapshot not available — refresh the application feed first")]);
 		return;
 	}
 	$appfeedEntry = null;
@@ -225,47 +226,28 @@ function caRenderAsJson(array $entry): string {
 }
 
 /**
- * Fetch (or reuse cached) applicationFeed.json for the dev-mode Diff buttons.
- * Returns the decoded array on success or null on any failure / invalid JSON.
- * Uses download_url's flock-based serializer so concurrent Diff clicks share
- * a single download instead of stacking up.
+ * Read the raw applicationFeed.json snapshot that DownloadApplicationFeed()
+ * stashes whenever dev mode is enabled (exec.php — the `@copy($downloadURL,
+ * CA_PATHS['diffFeedCache'])` line just before the per-request tempfile is
+ * unlinked). Returns the decoded array on success or null on any failure.
+ *
+ * No download / no flock: the file is rewritten on every feed refresh so in
+ * steady state it's always current. Cold start — dev mode was just turned on
+ * and the user hasn't hit Refresh yet — returns null and the caller surfaces
+ * "Could not download application feed", which is the cue to refresh.
  */
 function caGetCachedApplicationFeed(): ?array {
 	$cachePath = CA_PATHS['diffFeedCache'];
-	if (is_file($cachePath)) {
-		$decoded = json_decode((string)@file_get_contents($cachePath), true);
-		/* Require a non-empty applist — DownloadApplicationFeed validates the
-		   same way (exec.php:251). An empty applist from a transient bad
-		   primary response would otherwise poison the cache and break every
-		   subsequent Diff click with "app not found". */
-		if (is_array($decoded) && !empty($decoded['applist'] ?? null) && is_array($decoded['applist'])) {
-			return $decoded;
-		}
-		@unlink($cachePath);
+	if (!is_file($cachePath)) return null;
+	$decoded = json_decode((string)@file_get_contents($cachePath), true);
+	/* Require a non-empty applist — same shape DownloadApplicationFeed
+	   validates against. Anything else and we treat the snapshot as
+	   unusable rather than handing the diff code a malformed feed and
+	   watching it explode on a missing key downstream. */
+	if (is_array($decoded) && !empty($decoded['applist'] ?? null) && is_array($decoded['applist'])) {
+		return $decoded;
 	}
-	/* 10-minute cURL timeout — the ca_downloadProgress nchan stream lets
-	   the user see (and Abort) a long-running fetch, but the timeout caps
-	   the worst case if the connection silently stalls. download_json
-	   forwards $path to download_url so the flock-based serializer engages. */
-	$applicationFeed = download_json(CA_PATHS['application-feed'], $cachePath, 600);
-	$ok = is_array($applicationFeed)
-		&& is_array($applicationFeed['applist'] ?? null)
-		&& !empty($applicationFeed['applist']);
-	if (!$ok) {
-		/* Primary returned malformed / empty — mirror DownloadApplicationFeed
-		   and fall through to the GitHub mirror so a flaky CDN doesn't take
-		   the Diff feature offline. */
-		@unlink($cachePath);
-		$applicationFeed = download_json(CA_PATHS['pluginProxy'] . CA_PATHS['application-feedBackup'], $cachePath, 600);
-		$ok = is_array($applicationFeed)
-			&& is_array($applicationFeed['applist'] ?? null)
-			&& !empty($applicationFeed['applist']);
-	}
-	if (!$ok) {
-		@unlink($cachePath);
-		return null;
-	}
-	return $applicationFeed;
+	return null;
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -296,6 +296,16 @@ function DownloadApplicationFeed() {
 			ca_file_put_contents(CA_PATHS['appFeedDownloadError'],$downloadURL);
 			return false;
 		}
+		/* Dev mode: stash the raw applicationFeed.json before deleting the
+		   per-request tempfile so the Diff/Plugin/Template modals don't have
+		   to re-download it. tempFiles was wiped at the top of this function
+		   so the cache file is always fresh; outside dev mode we never write
+		   it, which keeps the steady-state footprint identical for normal
+		   users. caGetCachedApplicationFeed() reads this on every Diff
+		   click. */
+		if (($GLOBALS['caSettings']['dev'] ?? null) === "yes") {
+			@copy($downloadURL, CA_PATHS['diffFeedCache']);
+		}
 		/* Success — feed parsed cleanly, the per-request tempfile served its
 		   purpose. Clean it up so /tmp doesn't accumulate stale randomFile()s. */
 		@unlink($downloadURL);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
@@ -87,7 +87,7 @@ define("CA_PATHS",[
 	'application-feed-last-updatedBackup' => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed-lastUpdated.json",
 	'application-feed-local'              => "/tmp/GitHub/AppFeed/applicationFeed.json",
 	'appFeedDownloadError'                => "$tempFiles/downloaderror.txt",
-	'diffFeedCache'                       => "$tempFiles/diffApplicationFeed.json", /* cached copy of applicationFeed.json used only by the dev-mode Diff button */
+	'diffFeedCache'                       => "$tempFiles/diffApplicationFeed.json", /* raw applicationFeed.json snapshot — populated by DownloadApplicationFeed() ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
 	'caAdmin'                             => "/boot/config/plugins/community.applications/admin", /* marker file: when present alongside dev mode, exposes the Internal diff button */
 	'categoryList'                        => "$tempFiles/categoryList.json",
 	'repositoryList'                      => "$tempFiles/repositoryList.json",

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
@@ -87,7 +87,7 @@ define("CA_PATHS",[
 	'application-feed-last-updatedBackup' => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed-lastUpdated.json",
 	'application-feed-local'              => "/tmp/GitHub/AppFeed/applicationFeed.json",
 	'appFeedDownloadError'                => "$tempFiles/downloaderror.txt",
-	'diffFeedCache'                       => "$tempFiles/diffApplicationFeed.json", /* raw applicationFeed.json snapshot — populated by DownloadApplicationFeed() ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
+	'diffFeedCache'                       => "$tempFiles/applicationFeed-raw.json", /* raw applicationFeed.json snapshot — populated by DownloadApplicationFeed() ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
 	'caAdmin'                             => "/boot/config/plugins/community.applications/admin", /* marker file: when present alongside dev mode, exposes the Internal diff button */
 	'categoryList'                        => "$tempFiles/categoryList.json",
 	'repositoryList'                      => "$tempFiles/repositoryList.json",

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -280,10 +280,18 @@ function caBuildSupportContext(array $template, array $allRepositories) {
 		}
 		$diffPath = json_encode((string)($template['Path'] ?? ""), $jsFlags);
 		$diffName = json_encode((string)($template['Name'] ?? ""), $jsFlags);
+		/* Both Diff buttons go through caGetCachedApplicationFeed which reads
+		   the raw appfeed snapshot DownloadApplicationFeed() stashes to
+		   diffFeedCache (dev-mode only). Until that file lands on disk the
+		   buttons can't do anything useful — hide them entirely rather than
+		   render an option that errors out on click. Handles the edge case
+		   of opening a sidebar before the background feed download finishes
+		   on a slow connection. */
+		$diffFeedReady = is_file(CA_PATHS['diffFeedCache']);
 		/* Diff is container-only — plugin .plg payloads don't survive the
 		   array→XML round-trip cleanly and the resulting diff is more noise
 		   than signal. */
-		if (empty($template['Plugin'])) {
+		if ($diffFeedReady && empty($template['Plugin'])) {
 			$supportContext[] = [
 				"icon"   => "ca_fa-diff",
 				"action" => "caShowTemplateDiff({$diffPath},{$diffName},'feed')",
@@ -294,7 +302,7 @@ function caBuildSupportContext(array $template, array $allRepositories) {
 		/* Internal diff (appfeed vs CA's internal templates_full.json) — only
 		   when the admin marker file exists. Available for plugins too since
 		   neither side does a source-XML round-trip. */
-		if (is_file(CA_PATHS['caAdmin'])) {
+		if ($diffFeedReady && is_file(CA_PATHS['caAdmin'])) {
 			$supportContext[] = [
 				"icon"   => "ca_fa-diff",
 				"action" => "caShowTemplateDiff({$diffPath},{$diffName},'internal')",


### PR DESCRIPTION
## Summary
- `DownloadApplicationFeed()` already downloads `applicationFeed.json` into a per-request tempfile, parses it, and unlinks the file.
- The dev-mode Diff button needed the same raw bytes — it was lazily downloading them again on first click via `caGetCachedApplicationFeed → download_json` (with primary + GitHub-mirror fallback, flock, the works).
- Instead: when dev mode is enabled, `@copy` the per-request tempfile to `CA_PATHS['diffFeedCache']` right before it's unlinked. The cache lives inside `tempFiles`, which `DownloadApplicationFeed()` wipes at the top of the function — so it's always fresh and tracks the feed refresh cycle automatically. Outside dev mode nothing is written, so steady-state footprint is unchanged for normal users.

## Changes
- **`include/exec.php`**: in `DownloadApplicationFeed()`, add an `@copy($downloadURL, CA_PATHS['diffFeedCache'])` right before the per-request tempfile is unlinked, gated on `($GLOBALS['caSettings']['dev'] ?? null) === "yes"`.
- **`include/diff.php`**: `caGetCachedApplicationFeed()` collapses from "check cache, else download, else fall back to GitHub mirror" down to a straight read + applist validation. Cold-start error message updated from *"Could not download application feed"* to *"Application feed snapshot not available — refresh the application feed first"* to match the new behaviour.
- **`include/paths.php`**: comment on `diffFeedCache` updated to note the proactive population and dev-mode gating.

## Test plan
- [ ] Dev mode OFF: install/refresh CA, hit the appfeed refresh, verify `/tmp/community.applications/tempFiles/diffApplicationFeed.json` is **not** created.
- [ ] Dev mode ON, never refreshed feed: click a Diff button → see the *"refresh the application feed first"* message.
- [ ] Dev mode ON, after a refresh: verify the file is present and matches the upstream `applicationFeed.json`; Diff button works without any network call (DevTools / `lsof` confirms no fetch).
- [ ] Trigger another feed refresh → file mtime updates (matches the wipe-and-rewrite cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the application-feed snapshot: comparisons now require an existing cached snapshot and show a clear “Application feed snapshot not available — refresh the application feed first” message when missing.
  * Diff UI entries are hidden when the dev-mode feed snapshot is not present, preventing broken or confusing actions.

* **Chores**
  * Adjusted dev-mode feed caching so raw snapshots are stored for diff use and related docs/comments updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->