### PR TITLE
chore: gate JS console chatter behind caDebug() + drop attr-cache debug noise

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -286,6 +286,9 @@ var caCardCache = {
    Docker search tab when docker can't service it. The per-app "Docker not
    enabled" notice now lives in the sidebar template itself. */
 var dockerNotEnabled = <?= (!caIsDockerRunning() && !($GLOBALS['caSettings']['NoInstalls'] ?? false)) ? "true" : "false" ?>;
+/* Dev-mode flag — consumed by caDebug() (helpers.js) to gate diagnostic
+   chatter. When false (the default), caDebug is a no-op. */
+window.caDev = <?= (($GLOBALS['caSettings']['dev'] ?? "no") === "yes") ? "true" : "false" ?>;
 var postCount = 0;
 var cookieWarning = false;
 var restoreStateMenu = false;
@@ -388,7 +391,7 @@ $(function(){
 	// don't run this through the wrapper so that if it hangs up it won't delay anything else
 	$.post(execURL,{action:'getPortsInUse'},function(ret) {
 		portsInUse = ret.portsInUse;
-		console.log("Ports In Use:" + portsInUse);
+		caDebug("Ports In Use:" + portsInUse);
 	});
 
 	if ( "<?=$killCookie?>" == "true" ) { // This is needed so that if language gets switched on the home page the home page gets regenerated correctly
@@ -2234,7 +2237,7 @@ function saveState(legacy=true) {
 		$.removeCookie("ca_data", { path: "/" });
 		return;
 	}
-	console.log("Save State");
+	caDebug("Save State");
 	//$.cookie("ca_categoryText",$(".categoryLine").html(),{path:"/;SameSite=Lax"});
 	/* Strip out fields that re-derive from a fresh server fetch — the card
 	   cache + virt offsets can be 100s of KB which would blow past the 4KB
@@ -2264,7 +2267,7 @@ function saveState(legacy=true) {
  * Rehydrate cookies into `data`, search box, and menu; fetch sort order, autocomplete, and clear multi-select before the user continues.
  */
 function restoreState() {
-	console.log("Restore State");
+	caDebug("Restore State");
 	$.removeCookie("ca_languageSwitch",{path:'/'});
 
 	//$(".category").html($.cookie("ca_categoryText"));
@@ -2285,7 +2288,7 @@ function restoreState() {
 		data.loadingMore = false;
 		$.removeCookie("ca_data");
 	} catch (e) {
-		console.log("Unable to restore state - reloading to clear errors");
+		caDebug("Unable to restore state - reloading to clear errors");
 		$.removeCookie("ca_data");
 		post({action:"clearStartUpDisplayed"},function(result) {
 			window.location.reload();
@@ -2449,7 +2452,7 @@ function getCategories() {
 		if ( ! restoreStateMenu )
 			restoreStateMenu = $.cookie("ca_startupButton");
 
-		console.log(restoreStateMenu);
+		caDebug(restoreStateMenu);
 		var menuItem = $.find(".caMenuItem[data-category='"+restoreStateMenu+"']");
 		$(".caMenuItem").each(function(){
 			$(this).removeClass("selectedMenu");

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -177,7 +177,6 @@ function ca_plugin($method, $plugin_file = '',$dontCache = false) {
 			$dirty = false;
 			if ( is_file($plugin_file) ) {
 				if ( !isset($attributeCache[$plugin_file]) ) {
-					debug("CA Plugin $method $plugin_file not in attribute cache");
 					$xml = @simplexml_load_file($plugin_file, NULL, LIBXML_NOCDATA);
 					if ( $xml ) {
 						$attributes = $xml->attributes();
@@ -186,8 +185,6 @@ function ca_plugin($method, $plugin_file = '',$dontCache = false) {
 					}
 					$attributeCache[$plugin_file] = (array)$attributes ?: ["error" => "no attributes present"];
 					$dirty = true;
-				} else {
-					debug("$plugin_file already in attribute cache");
 				}
 			} else if ( isset($attributeCache[$plugin_file]) ) {
 				unset($attributeCache[$plugin_file]);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/helpers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/helpers.js
@@ -17,6 +17,25 @@ SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 /**
+ * Dev-gated console.log. No-op unless CA's dev mode is enabled.
+ *
+ * Apps.page sets `window.caDev` to `true` / `false` from
+ * $GLOBALS['caSettings']['dev'] before this is ever called. Wrapped in a
+ * try/catch so a broken console (e.g. swal-modal sandboxing) never throws
+ * out of a caller's middle.
+ *
+ * Use this instead of console.log() for diagnostic chatter you only want
+ * end users to see when they've explicitly turned dev mode on.
+ *
+ * @param {...*} _args Forwarded to console.log
+ * @returns {void}
+ */
+function caDebug() {
+	if (!window.caDev) return;
+	try { console.log.apply(console, arguments); } catch (e) { /* no-op */ }
+}
+
+/**
  * Parse `url` with the URL API; returns a `URL` instance or `false` if invalid.
  *
  * @param {string} url
@@ -724,7 +743,7 @@ function caShowFatalReloadBanner(message, _unusedDelay) {
  */
 function postNoSpin(options,callback) {
 	var msg = "No Spin Post: ";
-	console.log(msg+JSON.stringify(options));
+	caDebug(msg+JSON.stringify(options));
 	if ( typeof options === "function" ) {
 		callback = options;
 		options = {};
@@ -745,7 +764,7 @@ function post(options,callback) {
 		options = {};
 	} else {
 		var msg = postCount > 0 ? "Embedded Post: " : "Post: ";
-		console.log(msg+JSON.stringify(options));
+		caDebug(msg+JSON.stringify(options));
 	}
 	if ( ! options || typeof options !== "object" ) {
 		options = {};


### PR DESCRIPTION
## Summary
- **JS** — new `caDebug()` helper in `javascript/helpers.js`. No-op unless `window.caDev` is true (Apps.page sets it from `$GLOBALS['caSettings']['dev']`). Used to gate the diagnostic `console.log` calls that were firing in every end user's devtools console even when they didn't have dev mode on.
- All seven user-facing `console.log` calls swapped to `caDebug()` (5 in `Apps.page`: ports-in-use list, Save/Restore State, restore-failed reload notice, restoreStateMenu dump; 2 in `helpers.js`: post / postNoSpin tracing).
- The single `console.warn('IntersectionObserver not supported')` stays — that's a real compat warning on ancient browsers, not the chatty per-action noise we're quieting.
- **PHP** — drop the paired `debug()` lines in `ca_plugin()`'s attribute-cache branch (`"not in attribute cache"` / `"already in attribute cache"`). They were useful while validating the cache wiring; now the path is solid and the entries just flood the CA debug log with one line per attribute lookup.

## Test plan
- [ ] Dev mode OFF (default): refresh CA, open devtools — no "Post: …" / "No Spin Post: …" / "Save State" / "Restore State" / "Ports In Use:" lines.
- [ ] Dev mode ON: same actions surface the lines as before.
- [ ] Tail the CA debug log during a sidebar open with many plugins — no more "not in attribute cache" / "already in attribute cache" entries; everything else still shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined diagnostic logging infrastructure with development mode gating to optimize output verbosity
  * Streamlined debug output behavior across multiple components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->