### PR TITLE
feat: sidebar action button restyle — color/icon/layout per action class

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,9 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: Sidebar action buttons restyled — Install / Reinstall / Install second are blue, Update is green, Uninstall / Remove are red, all right-aligned and icon-prefixed; secondary buttons (WebUI / Edit / Pin / etc.) stay on the left with a visual separator between the two groups
+- Changed: Screenshot / video popup close button now floats at a fixed position top-right, larger and red
+- Changed: "Install second instance" button label shortened to "Install second"; "Tailscale WebUI" shortened to "TS WebUI"
 - Fixed: Closed a stored-XSS path in the sidebar popup's Install / Update buttons — a hostile maintainer publishing a template with a crafted `RequiresFile` value could otherwise execute arbitrary JS in the user's Unraid GUI session when the user clicked the button
 - Changed: Icon, screenshot, README, and changelog image URLs now reject private-network hosts (RFC1918, link-local, CGNAT, IPv6 ULA, plus `.local` / `.internal` / `.lan` mDNS-style hostnames) — closes a CSRF surface where an auto-loaded image could fire a request at a device on the user's LAN
 - Added: `referrerpolicy='no-referrer'` on every template-supplied image (popup icon, card icon, screenshots, video thumbnails, licence, README / changelog images) so a third-party host doesn't see the user's Unraid URL on each render

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -3099,7 +3099,7 @@ function showSidebarApp(apppath,appname) {
 			   never enabled the module — `r.enabled` was undefined). */
 			$('.caMediaGallery').magnificPopup({
 				delegate: '.screenshot',
-				closeMarkup: "<span class='mfp-close magnificPopup caButton'>"+tr("CLOSE")+"</span>",
+				closeMarkup: "<span class='mfp-close magnificPopup caButton caButtonLarge caButtonRed'>"+tr("CLOSE")+"</span>",
 				/* Gallery mode: don't close on content click — gallery's own
 				   navigateByImgClick handles image clicks (advances to next).
 				   Otherwise the click both advances AND closes. */
@@ -3136,7 +3136,7 @@ function showSidebarApp(apppath,appname) {
 			   (eg. the popup app icon) get a plain single-item popup. */
 			$('.screenshot').not($('.caMediaGallery').find('.screenshot')).magnificPopup({
 				type:'image',
-				closeMarkup: "<span class='mfp-close magnificPopup caButton'>"+tr("CLOSE")+"</span>",
+				closeMarkup: "<span class='mfp-close magnificPopup caButton caButtonLarge caButtonRed'>"+tr("CLOSE")+"</span>",
 				closeOnContentClick: true,
 				removalDelay: 100,
 				mainClass: 'mfp-fade',
@@ -3511,7 +3511,7 @@ function showRepoPopup(repository) {
 		   from their own `mfp-image`/`mfp-iframe` class. */
 		$('.caMediaGallery').magnificPopup({
 			delegate: '.screenshot',
-			closeMarkup: "<span class='mfp-close magnificPopup caButton'>"+tr("CLOSE")+"</span>",
+			closeMarkup: "<span class='mfp-close magnificPopup caButton caButtonLarge caButtonRed'>"+tr("CLOSE")+"</span>",
 			closeOnContentClick: false,    /* gallery's navigateByImgClick handles image clicks */
 			removalDelay: 100,
 			mainClass: 'mfp-fade',
@@ -3543,7 +3543,7 @@ function showRepoPopup(repository) {
 		});
 		$('.screenshot').not($('.caMediaGallery').find('.screenshot')).magnificPopup({
 			type:'image',
-			closeMarkup: "<span class='mfp-close magnificPopup caButton'>"+tr("CLOSE")+"</span>",
+			closeMarkup: "<span class='mfp-close magnificPopup caButton caButtonLarge caButtonRed'>"+tr("CLOSE")+"</span>",
 			closeOnContentClick: true,
 			removalDelay: 100,
 			mainClass: 'mfp-fade',

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -604,56 +604,56 @@ function displayPopup($template) {
 
 				<?php /* === LEFT GROUP ============================================ */ ?>
 				<?php if (!empty($popupShortcut['action'])): ?>
-					<div class='caButton actionsPopup <?= htmlspecialchars($popupShortcut['icon'] ?? '', ENT_QUOTES) ?>'><span onclick="<?= htmlspecialchars($popupShortcut['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $popupShortcut['text'] ?? tr("WebUI")) ?></span></div>
+					<div class='caButton actionsPopup <?= htmlspecialchars($popupShortcut['icon'] ?? '', ENT_QUOTES) ?>'><span onclick="<?= htmlspecialchars($popupShortcut['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)($popupShortcut['text'] ?? tr("WebUI")))), ENT_QUOTES) ?></span></div>
 				<?php endif; ?>
 				<?= $readmeButton ?>
 
 				<?php foreach ($leftActionItems as $actionItem): ?>
 					<?php $iconClass = htmlspecialchars($actionItem['icon'] ?? '', ENT_QUOTES); ?>
 					<?php if (!empty($actionItem['action'])): ?>
-						<div class='caButton actionsPopup <?= $iconClass ?>'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup <?= $iconClass ?>'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php else: ?>
-						<div class='caButton actionsPopup <?= $iconClass ?>'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup <?= $iconClass ?>'><span><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php endif; ?>
 				<?php endforeach; ?>
 
 				<?php if ($LanguagePack !== "en_US" && ! $Blacklist && ! $NoPin): ?>
-					<div class='caButton pinPopup <?= $pinnedClass ?>' data-repository='<?= $Repository ?>' data-name='<?= $SortName ?>'><span><?= tr("Pin") ?></span></div>
+					<div class='caButton pinPopup <?= htmlspecialchars((string)$pinnedClass, ENT_QUOTES) ?>' data-repository='<?= htmlspecialchars((string)$Repository, ENT_QUOTES) ?>' data-name='<?= htmlspecialchars((string)$SortName, ENT_QUOTES) ?>'><span><?= tr("Pin") ?></span></div>
 				<?php endif; ?>
 
 				<?php /* === RIGHT BLUE GROUP — install-family ===================== */ ?>
 				<?php if (!empty($installFirstAction['action'])): ?>
-					<div class='caButton actionsPopup actionsInstall'><span onclick="<?= htmlspecialchars($installFirstAction['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $installFirstAction['text']) ?></span></div>
+					<div class='caButton actionsPopup actionsInstall'><span onclick="<?= htmlspecialchars($installFirstAction['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)$installFirstAction['text'])), ENT_QUOTES) ?></span></div>
 				<?php endif; ?>
 
 				<?php foreach ($rightInstallActionItems as $actionItem): ?>
 					<?php if (!empty($actionItem['action'])): ?>
-						<div class='caButton actionsPopup actionsInstall'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup actionsInstall'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php else: ?>
-						<div class='caButton actionsPopup actionsInstall'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup actionsInstall'><span><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php endif; ?>
 				<?php endforeach; ?>
 
 				<?php /* === RIGHT GREEN GROUP — Update ============================ */ ?>
 				<?php foreach ($rightUpdateActionItems as $actionItem): ?>
 					<?php if (!empty($actionItem['action'])): ?>
-						<div class='caButton actionsPopup actionsUpdate'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup actionsUpdate'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php else: ?>
-						<div class='caButton actionsPopup actionsUpdate'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup actionsUpdate'><span><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php endif; ?>
 				<?php endforeach; ?>
 
 				<?php /* === RIGHT RED GROUP — destructive ========================= */ ?>
 				<?php foreach ($rightUninstallActionItems as $actionItem): ?>
 					<?php if (!empty($actionItem['action'])): ?>
-						<div class='caButton actionsPopup actionsUninstall'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup actionsUninstall'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php else: ?>
-						<div class='caButton actionsPopup actionsUninstall'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+						<div class='caButton actionsPopup actionsUninstall'><span><?= htmlspecialchars(trim(strip_tags((string)($actionItem['text'] ?? ""))), ENT_QUOTES) ?></span></div>
 					<?php endif; ?>
 				<?php endforeach; ?>
 
 				<?php if (!empty($popupUninstallAction['action'])): ?>
-					<div class='caButton actionsPopup actionsUninstall'><span onclick="<?= htmlspecialchars($popupUninstallAction['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $popupUninstallAction['text'] ?? tr("Uninstall")) ?></span></div>
+					<div class='caButton actionsPopup actionsUninstall'><span onclick="<?= htmlspecialchars($popupUninstallAction['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)($popupUninstallAction['text'] ?? tr("Uninstall")))), ENT_QUOTES) ?></span></div>
 				<?php endif; ?>
 			</div>
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -470,6 +470,50 @@ function displayPopup($template) {
 		$actionsButtonItems[] = $context;
 	}
 
+	/* Partition $actionsButtonItems into three visual groups so the popup
+	   action row can right-align primary install actions (blue) and
+	   destructive actions (red) while keeping secondary actions (Edit,
+	   Pin, etc.) on the left. The CSS uses a margin-left:auto trick on
+	   .actionsInstall / .actionsUninstall to push the right group to the
+	   far edge, which requires the DOM order to be LEFT first then RIGHT
+	   — render the three buckets in sequence below in .popupStickyActions.
+
+	   Matching on `strip_tags`-stripped text because some labels arrive
+	   wrapped in <span class='ca_red'> (eg. plugin "Remove", "Reinstall
+	   From Previous Apps") that gets stripped later for visual display
+	   anyway. Also accepts the untranslated English variants so the
+	   detection survives a missing/partial locale file. */
+	$installFamilyTexts = [
+		tr("Install"), tr("Reinstall"),
+		tr("Install second"), tr("Reinstall From Previous Apps"),
+		"Install", "Reinstall",
+		"Install second", "Reinstall From Previous Apps",
+	];
+	$updateFamilyTexts = [
+		tr("Update"),
+		"Update",
+	];
+	$uninstallFamilyTexts = [
+		tr("Uninstall"), tr("Remove"),
+		"Uninstall", "Remove",
+	];
+	$leftActionItems = [];
+	$rightInstallActionItems = [];
+	$rightUpdateActionItems = [];
+	$rightUninstallActionItems = [];
+	foreach ($actionsButtonItems as $actionItem) {
+		$itemText = trim(strip_tags((string)($actionItem['text'] ?? "")));
+		if (in_array($itemText, $installFamilyTexts, true)) {
+			$rightInstallActionItems[] = $actionItem;
+		} elseif (in_array($itemText, $updateFamilyTexts, true)) {
+			$rightUpdateActionItems[] = $actionItem;
+		} elseif (in_array($itemText, $uninstallFamilyTexts, true)) {
+			$rightUninstallActionItems[] = $actionItem;
+		} else {
+			$leftActionItems[] = $actionItem;
+		}
+	}
+
 	ob_start();
 	?>
 	<div class='popup'>
@@ -521,10 +565,17 @@ function displayPopup($template) {
 				</div>
 			</div>
 			<?php /* Action buttons only — gets relocated to .popupCloseAreaButtons
-			         by Apps.page's caRelocatePopupActions() at popup-load time. */ ?>
+			         by Apps.page's caRelocatePopupActions() at popup-load time.
+
+			         Emission order matters: LEFT items first (WebUI shortcut,
+			         Read Me First, other secondary actions, Pin), then RIGHT
+			         BLUE (install-family — Install / Reinstall / Install
+			         second instance), then RIGHT GREEN (Update), then RIGHT
+			         RED (Uninstall / Remove). The CSS's `margin-left:auto`
+			         push on .actionsInstall / .actionsUpdate / .actionsUninstall
+			         (community.applications.css) relies on this DOM order to
+			         right-align the right group as one contiguous block. */ ?>
 			<div class='popupStickyActions'>
-				<?php /* Primary action row: Install / WebUI / Settings, then
-				         Update / Edit / Uninstall / Pin. */ ?>
 				<?php /* Always htmlspecialchars(..., ENT_QUOTES) the action onclick — these
 				         strings get built with interpolated template data (RequiresFile,
 				         pluginName, paths, etc.) and an unescaped emit lets a hostile
@@ -534,31 +585,75 @@ function displayPopup($template) {
 				         match. The browser decodes the entities back to literal quotes
 				         when parsing the onclick attribute, so the resulting JS is
 				         identical to the un-escaped form for legitimate inputs. */ ?>
-				<?php if (!empty($installFirstAction['action'])): ?>
-					<div class='caButton actionsPopup'><span onclick="<?= htmlspecialchars($installFirstAction['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $installFirstAction['text']) ?></span></div>
-				<?php endif; ?>
 
+				<?php /* Two icon paths in this block:
+				         - LEFT GROUP buttons (popupShortcut, leftActionItems)
+				           all share .caButton.actionsPopup with no per-action
+				           differentiator, so their FontAwesome glyph is
+				           attached by threading $context['icon'] (a
+				           ca_fa-XXX class set by skin_helpers.php) into the
+				           outer class list. htmlspecialchars on every
+				           interpolation because the strings come from the
+				           template feed.
+				         - RIGHT GROUP / pin buttons have unique semantic
+				           classes (.actionsInstall / .actionsUpdate /
+				           .actionsUninstall / .pinPopup), so their icons
+				           are attached purely in CSS via ::before — see
+				           community.applications.css. No class threading
+				           needed here for those. */ ?>
+
+				<?php /* === LEFT GROUP ============================================ */ ?>
 				<?php if (!empty($popupShortcut['action'])): ?>
-					<div class='caButton actionsPopup'><span onclick="<?= htmlspecialchars($popupShortcut['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $popupShortcut['text'] ?? tr("WebUI")) ?></span></div>
+					<div class='caButton actionsPopup <?= htmlspecialchars($popupShortcut['icon'] ?? '', ENT_QUOTES) ?>'><span onclick="<?= htmlspecialchars($popupShortcut['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $popupShortcut['text'] ?? tr("WebUI")) ?></span></div>
 				<?php endif; ?>
 				<?= $readmeButton ?>
 
-				<?php if ($actionsButtonItems): ?>
-					<?php foreach ($actionsButtonItems as $actionItem): ?>
-						<?php if (!empty($actionItem['action'])): ?>
-							<div class='caButton actionsPopup'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
-						<?php else: ?>
-							<div class='caButton actionsPopup'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
-						<?php endif; ?>
-					<?php endforeach; ?>
-				<?php endif; ?>
-
-				<?php if (!empty($popupUninstallAction['action'])): ?>
-					<div class='caButton actionsPopup'><span onclick="<?= htmlspecialchars($popupUninstallAction['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $popupUninstallAction['text'] ?? tr("Uninstall")) ?></span></div>
-				<?php endif; ?>
+				<?php foreach ($leftActionItems as $actionItem): ?>
+					<?php $iconClass = htmlspecialchars($actionItem['icon'] ?? '', ENT_QUOTES); ?>
+					<?php if (!empty($actionItem['action'])): ?>
+						<div class='caButton actionsPopup <?= $iconClass ?>'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php else: ?>
+						<div class='caButton actionsPopup <?= $iconClass ?>'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php endif; ?>
+				<?php endforeach; ?>
 
 				<?php if ($LanguagePack !== "en_US" && ! $Blacklist && ! $NoPin): ?>
 					<div class='caButton pinPopup <?= $pinnedClass ?>' data-repository='<?= $Repository ?>' data-name='<?= $SortName ?>'><span><?= tr("Pin") ?></span></div>
+				<?php endif; ?>
+
+				<?php /* === RIGHT BLUE GROUP — install-family ===================== */ ?>
+				<?php if (!empty($installFirstAction['action'])): ?>
+					<div class='caButton actionsPopup actionsInstall'><span onclick="<?= htmlspecialchars($installFirstAction['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $installFirstAction['text']) ?></span></div>
+				<?php endif; ?>
+
+				<?php foreach ($rightInstallActionItems as $actionItem): ?>
+					<?php if (!empty($actionItem['action'])): ?>
+						<div class='caButton actionsPopup actionsInstall'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php else: ?>
+						<div class='caButton actionsPopup actionsInstall'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php endif; ?>
+				<?php endforeach; ?>
+
+				<?php /* === RIGHT GREEN GROUP — Update ============================ */ ?>
+				<?php foreach ($rightUpdateActionItems as $actionItem): ?>
+					<?php if (!empty($actionItem['action'])): ?>
+						<div class='caButton actionsPopup actionsUpdate'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php else: ?>
+						<div class='caButton actionsPopup actionsUpdate'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php endif; ?>
+				<?php endforeach; ?>
+
+				<?php /* === RIGHT RED GROUP — destructive ========================= */ ?>
+				<?php foreach ($rightUninstallActionItems as $actionItem): ?>
+					<?php if (!empty($actionItem['action'])): ?>
+						<div class='caButton actionsPopup actionsUninstall'><span onclick="<?= htmlspecialchars($actionItem['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php else: ?>
+						<div class='caButton actionsPopup actionsUninstall'><span><?= str_replace("ca_red", "", $actionItem['text'] ?? "") ?></span></div>
+					<?php endif; ?>
+				<?php endforeach; ?>
+
+				<?php if (!empty($popupUninstallAction['action'])): ?>
+					<div class='caButton actionsPopup actionsUninstall'><span onclick="<?= htmlspecialchars($popupUninstallAction['action'], ENT_QUOTES) ?>"><?= str_replace("ca_red", "", $popupUninstallAction['text'] ?? tr("Uninstall")) ?></span></div>
 				<?php endif; ?>
 			</div>
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -484,7 +484,7 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 					if (($info[$name]['url'] ?? false) && ($info[$name]['running'] ?? false)) {
 						$actionsContext[] = ["icon"=>"ca_fa-globe","text"=>tr("WebUI"),"action"=>"openNewWindow('{$info[$name]['url']}','_blank');"];
 						if ($info[$name]['TSurl'] ?? false) {
-							$actionsContext[] = ["icon"=>"ca_fa-globe","text"=>tr("Tailscale WebUI"),"action"=>"openNewWindow('{$info[$name]['TSurl']}','_blank');"];
+							$actionsContext[] = ["icon"=>"ca_fa-globe","text"=>tr("TS WebUI"),"action"=>"openNewWindow('{$info[$name]['TSurl']}','_blank');"];
 						}
 					}
 					/* Detect image tag presence by checking for `:` AFTER the last `/`
@@ -504,9 +504,9 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 					}
 					if ($GLOBALS['caSettings']['defaultReinstall'] == "true" && !$template['Blacklist'] && $template['ID'] !== false) {
 						if ($template['BranchID'] ?? false) {
-							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second instance"),"action"=>"displayTags('{$template['ID']}',true,'".$template['PortsUsed']."');"];
+							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second"),"action"=>"displayTags('{$template['ID']}',true,'".$template['PortsUsed']."');"];
 						} else {
-							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second instance"),"action"=>"popupInstallXML('".addslashes($template['Path'])."','second','".$template['PortsUsed']."');"];
+							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second"),"action"=>"popupInstallXML('".addslashes($template['Path'])."','second','".$template['PortsUsed']."');"];
 						}
 					}
 					if (is_file($info[$name]['template'])) {
@@ -816,7 +816,7 @@ function caProcessDockerTemplate(array $template, array $info, array $dockerUpda
 			if ($info[$ind]['url'] && $info[$ind]['running']) {
 				$actionsContext[] = ["icon" => "ca_fa-globe", "text" => tr("WebUI"), "action" => "openNewWindow('{$info[$ind]['url']}','_blank');"];
 				if ($info[$ind]['TSurl'] ?? false) {
-					$actionsContext[] = ["icon" => "ca_fa-globe", "text" => tr("Tailscale WebUI"), "action" => "openNewWindow('{$info[$ind]['TSurl']}','_blank');"];
+					$actionsContext[] = ["icon" => "ca_fa-globe", "text" => tr("TS WebUI"), "action" => "openNewWindow('{$info[$ind]['TSurl']}','_blank');"];
 				}
 			}
 
@@ -838,9 +838,9 @@ function caProcessDockerTemplate(array $template, array $info, array $dockerUpda
 			if ($GLOBALS['caSettings']['defaultReinstall'] == "true" && ! $template['Blacklist']) {
 				if ($template['ID'] !== false) {
 					if ($template['BranchID'] ?? false) {
-						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second instance"), "action" => "displayTags('{$template['ID']}',true,'".$template['PortsUsed']."');"];
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second"), "action" => "displayTags('{$template['ID']}',true,'".$template['PortsUsed']."');"];
 					} else {
-						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second instance"), "action" => "popupInstallXML('".addslashes($template['Path'])."','second','".$template['PortsUsed']."');"];
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second"), "action" => "popupInstallXML('".addslashes($template['Path'])."','second','".$template['PortsUsed']."');"];
 					}
 				}
 			}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -491,6 +491,121 @@ body,
 		text-decoration: none;
 	}
 
+	/* === Reusable button-style modifiers ==================================
+	   Composable utility classes intended to be stacked onto .caButton-like
+	   elements (or anywhere else that wants the same visual). Kept as two
+	   independent classes — size and color — so each can be used on its
+	   own; the MFP close button currently uses both, future callers can
+	   pick whichever they need.
+
+	   `!important` on the visual declarations is intentional: these are
+	   utility modifiers whose whole job is to win over context-specific
+	   button styling (eg. `.magnificPopup.caButton` sets font-size:1.5rem
+	   and color via --magnificCloseColor; the point of dropping caButtonLarge
+	   / caButtonRed onto a button is to override exactly those choices).
+	   Position-related declarations are deliberately NOT here — layout
+	   stays in the context-specific rule for whichever element uses these. */
+
+	.caButtonLarge {
+		font-size: 2.1rem !important;    /* ~75% larger than the .magnificPopup.caButton default of 1.5rem */
+		line-height: 2.6rem !important;
+		padding: 2px 16px !important;
+	}
+
+	.caButtonRed {
+		background: var(--ca-button-red) !important;
+		color: var(--ca-white-color) !important;
+	}
+	.caButtonRed:hover {
+		background: var(--ca-button-red-hover) !important;
+		color: var(--ca-white-color) !important;
+	}
+
+	/* Native red-paint for known close-action buttons that already have a
+	   distinct hook class (sidebar CLOSE, dev-mode diff overlay CLOSE).
+	   Compound selectors are 0,2,0 / 0,2,1 — naturally outrank `.caButton`
+	   (0,1,0) and `.caButton:hover` (0,1,1) without needing !important or
+	   touching the markup. The .caButtonRed utility above is still the
+	   right tool when a button doesn't have a stable class hook (eg. the
+	   per-call MFP closeMarkup string) or when red is being stacked with
+	   other modifiers like .caButtonLarge. */
+	.popUpClose.caButton,
+	.caDiffClose.caButton {
+		background: var(--ca-button-red);
+		color: var(--ca-white-color);
+	}
+	.popUpClose.caButton:hover,
+	.caDiffClose.caButton:hover {
+		background: var(--ca-button-red-hover);
+		color: var(--ca-white-color);
+	}
+
+	/* Sidebar action-row coloring. .actionsInstall = primary install-family
+	   (Install / Update / Reinstall / Install second instance) in blue;
+	   .actionsUninstall = destructive (Uninstall / Remove) in red. Both
+	   classes are applied by skin.php when the matching text is detected.
+	   Compound selectors are 0,2,0 / 0,2,1 — naturally outrank `.caButton`
+	   (0,1,0) and `.caButton:hover` (0,1,1) without needing !important. */
+	.popupStickyActions > .actionsInstall {
+		background: var(--ca-button-blue);
+		color: var(--ca-white-color);
+	}
+	.popupStickyActions > .actionsInstall:hover {
+		background: var(--ca-button-blue-hover);
+		color: var(--ca-white-color);
+	}
+	.popupStickyActions > .actionsUpdate {
+		background: var(--ca-button-green);
+		color: var(--ca-white-color);
+	}
+	.popupStickyActions > .actionsUpdate:hover {
+		background: var(--ca-button-green-hover);
+		color: var(--ca-white-color);
+	}
+	.popupStickyActions > .actionsUninstall {
+		background: var(--ca-button-red);
+		color: var(--ca-white-color);
+	}
+	.popupStickyActions > .actionsUninstall:hover {
+		background: var(--ca-button-red-hover);
+		color: var(--ca-white-color);
+	}
+	/* Push the right-group buttons (install-family + uninstall) to the far
+	   right of the action row while keeping the same wrap/gap behavior.
+	   Two-rule trick:
+	     1. Give every right-group button margin-left:auto. If we stopped
+	        here, the auto-margins would distribute evenly between siblings
+	        (like justify-content:space-between for the subset) and the
+	        right group would spread out across the row instead of packing.
+	     2. Strip the auto-margin from any right-group item that is preceded
+	        by another right-group sibling. Only the FIRST one in DOM order
+	        keeps margin-left:auto and consumes the available row space;
+	        the rest sit next to it with the container's normal column-gap.
+	   Requires the PHP markup to emit LEFT items first, then RIGHT items
+	   — see skin.php's .popupStickyActions block.
+
+	   Selector includes `.caButton` (0,3,0) to outrank the existing
+	   `.popupStickyActions > .caButton { margin: 0 }` margin-reset further
+	   down in this file (0,2,0, same specificity but later in source order)
+	   — without the extra class the reset zeroes out our auto-margin and
+	   the right group ends up packed immediately after the left group. */
+	.popupStickyActions > .actionsInstall.caButton,
+	.popupStickyActions > .actionsUpdate.caButton,
+	.popupStickyActions > .actionsUninstall.caButton {
+		margin-left: auto;
+	}
+	.popupStickyActions > .actionsInstall.caButton ~ .actionsInstall.caButton,
+	.popupStickyActions > .actionsInstall.caButton ~ .actionsUpdate.caButton,
+	.popupStickyActions > .actionsInstall.caButton ~ .actionsUninstall.caButton,
+	.popupStickyActions > .actionsUpdate.caButton ~ .actionsInstall.caButton,
+	.popupStickyActions > .actionsUpdate.caButton ~ .actionsUpdate.caButton,
+	.popupStickyActions > .actionsUpdate.caButton ~ .actionsUninstall.caButton,
+	.popupStickyActions > .actionsUninstall.caButton ~ .actionsInstall.caButton,
+	.popupStickyActions > .actionsUninstall.caButton ~ .actionsUpdate.caButton,
+	.popupStickyActions > .actionsUninstall.caButton ~ .actionsUninstall.caButton {
+		margin-left: 0;
+	}
+
 	/* Awesomplete suggestions: use caButton styling, force precedence */
 	body.ca_searchModalOpen #searchFilter .awesomplete > ul > li.caButton {
 		display: inline-block !important;
@@ -2392,12 +2507,91 @@ input[type="button"] {
 	   caRelocatePopupActions() moves them there at popup-load time.
 	   .popupCloseArea is already position:fixed, so this row is naturally
 	   pinned to the top of the sidebar for the entire scroll. */
+	/* FontAwesome icons attached directly via ::before to buttons that have
+	   a stable semantic class. The left-group action items (Edit, WebUI,
+	   TS WebUI, etc.) all share .caButton.actionsPopup with no per-action
+	   differentiator, so those still get their icon class threaded from
+	   PHP ($context['icon']) — see skin.php's left group render. The right-
+	   group / close / back / pin buttons all have a unique semantic class,
+	   so the icon lives entirely in CSS — no PHP class threading or markup
+	   change needed when the glyph changes. */
+	.popUpClose::before,
+	.caDiffClose::before,
+	.actionsUninstall::before {
+		content: "\f00d";              /* fa-times — close / destructive */
+		font-family: fontAwesome;
+	}
+	.popUpBack::before,
+	.popUpStat::before {
+		content: "\f060";              /* fa-arrow-left — back navigation */
+		font-family: fontAwesome;
+	}
+	.actionsInstall::before {
+		content: "\f019";              /* fa-download — install / reinstall / install second */
+		font-family: fontAwesome;
+	}
+	.actionsUpdate::before {
+		content: "\f0ed";              /* fa-arrow-circle-o-down — update */
+		font-family: fontAwesome;
+	}
+	.pinPopup::before {
+		content: "\f08d";              /* fa-thumb-tack — pin */
+		font-family: fontAwesome;
+	}
+
+	/* Small gap between the FontAwesome icon (rendered as ::before either
+	   directly or via the ca_fa-* helper class) and the button label, so
+	   the icon doesn't sit flush against the first character of the text.
+	   Scoped to the action-row and the close-area pill buttons so unrelated
+	   ::before pseudo-elements elsewhere in the app (which don't have a
+	   `content` set on the matching element) aren't affected — ::before
+	   only renders when `content` is provided, so this is a no-op on
+	   icon-less buttons. */
+	.popupCloseAreaButtons .popUpClose::before,
+	.popupCloseAreaButtons .caButton::before,
+	#caDiffView .caDiffClose::before {
+		margin-right: 0.5rem;
+	}
+
+	/* Pipe separator between CLOSE and the relocated action row. Without
+	   it the wide column-gap between CLOSE and the first action button
+	   reads as random spacing; the pipe punctuates the gap so it looks
+	   deliberate. Scoped to `.popupCloseAreaButtons .popupStickyActions`
+	   so the pseudo only renders AFTER caRelocatePopupActions() has moved
+	   the strip into the close area — before relocation the strip lives
+	   inside .popupContent (no CLOSE alongside it) and a stray pipe at
+	   the start of the row would look like a glitch. */
+	.popupCloseAreaButtons .popupStickyActions::before {
+		content: "|";
+		color: var(--sidebar-text);
+		opacity: 0.4;
+		font-size: 1.8rem;
+		line-height: 1;
+		align-self: center;
+	}
 	.popupStickyActions {
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
 		row-gap: 0.5rem;
 		column-gap: 1rem;
+		/* Grow to fill the remaining width inside .popupCloseAreaButtons
+		   (after CLOSE / BACK / popUpStat), so the margin-left:auto trick
+		   on .actionsInstall / .actionsUninstall has actual slack to
+		   consume — without this, .popupStickyActions is sized to its
+		   children (default flex: 0 1 auto), the auto-margin has zero
+		   remaining space to eat, and the right group ends up packed
+		   immediately after the left group instead of pushed to the far
+		   edge. Harmless before caRelocatePopupActions() runs because
+		   .popupContent isn't a flex container. */
+		flex-grow: 1;
+		/* Mirror the CLOSE button's left inset (`.popupCloseArea >
+		   div:first-child { margin-left: 2rem }`) so the right group ends
+		   the same distance from the sidebar's right edge as CLOSE does
+		   from the left. The padding shrinks the available row space, so
+		   the auto-margin push above still snaps the right group to the
+		   (now-2rem-inset) right edge. */
+		padding-right: 2rem;
 	}
 	/* CLOSE / BACK sit on the left, then a big gap, then the relocated
 	   per-app action row. Wrap so a wide button row can drop to the next
@@ -3328,10 +3522,6 @@ input[type="button"] {
 		font-family: Arial, Baskerville, monospace;
 	}
 
-	.mfp-close:hover {
-		color: var(--unraid-66-color) !important;
-	}
-
 	.mfp-close:active {
 		top: 1px;
 	}
@@ -3341,29 +3531,27 @@ input[type="button"] {
 	}
 
 	/* Our custom MFP close button carries .mfp-close (so the lib's
-	   _checkIfClose detection fires + position rules below apply) AND
-	   .caButton (so it visually matches the rest of CA's pill buttons).
-	   Use the holder-scoped selector so specificity (0,3,0) beats the
-	   `.mfp-image-holder .mfp-close` / `.mfp-iframe-holder .mfp-close`
-	   rule below that otherwise paints the close text red. Hover override
-	   uses 0,3,1 to outrank `.mfp-close:hover` (0,1,1 with !important). */
+	   _checkIfClose detection fires + the MagnificPopup library's own
+	   positioning hooks still apply) AND .caButton (so it picks up CA's
+	   pill styling), plus the .caButtonLarge / .caButtonRed utility
+	   modifiers for size + color (defined above near .caButton).
+
+	   This rule keeps only layout + library-default resets — sizing,
+	   color, and hover are now owned by the utility modifiers. Pinning
+	   position:fixed at top/right=1.5rem floats the button in a fixed
+	   spot regardless of which MFP content type (image / iframe) is up
+	   and how far the user has scrolled the lightbox. */
 	.mfp-image-holder .mfp-close.caButton,
 	.mfp-iframe-holder .mfp-close.caButton {
+		position: fixed;
+		top: 1.5rem;
+		right: 1.5rem;
 		height: auto;
-		line-height: 2rem;
-		padding: 1px 10px;
-		font-size: 1.2rem;
-		color: var(--support-popup-text);
+		width: auto;
 		font-family: inherit;
 		font-weight: normal;
 		opacity: 1;
-		width: auto;
 		text-align: center;
-		right: 0;
-	}
-	.mfp-image-holder .mfp-close.caButton:hover,
-	.mfp-iframe-holder .mfp-close.caButton:hover {
-		color: var(--ca-white-color) !important;
 	}
 
 	.mfp-image-holder .mfp-close,

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/azure.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/azure.css
@@ -15,6 +15,22 @@
 		--support-popup-text: #1b1d1b;
 		--support-popup-background: #ffffff;
 		--unraid-66-color: var(--orange-500,#FF8C2F);
+		/* Red-button palette (.caButtonRed). Base is a strong, readable close-
+		   action red shared across themes; hover lifts to the brand orange for
+		   the same affordance as the default .caButton:hover. Defined per-
+		   theme so individual themes can tweak later without disturbing the
+		   default contract. */
+		--ca-button-red: #cc1f1f;
+		--ca-button-red-hover: var(--unraid-66-color);
+		/* Blue-button palette (.actionsInstall and any future install-family
+		   button). Hover lifts to the brand orange for the same affordance
+		   as the default .caButton:hover. */
+		--ca-button-blue: #2870c3;
+		--ca-button-blue-hover: var(--unraid-66-color);
+		/* Green-button palette (.actionsUpdate). Same hover contract as
+		   the blue/red variants — lifts to brand orange. */
+		--ca-button-green: #2ca22c;
+		--ca-button-green-hover: var(--unraid-66-color);
 		--ca-legacy-background-color: var(--background-color,#e8e8e8);
 		--ca-search-modal-background: var(--ca-legacy-background-color);
 		--search-area-top: 0;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/black.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/black.css
@@ -15,6 +15,22 @@
 	--support-popup-text: #000000;
 	--support-popup-background: #ffffff;
 	--unraid-66-color: var(--orange-500,#FF8C2F);
+	/* Red-button palette (.caButtonRed). Base is a strong, readable close-
+	   action red shared across themes; hover lifts to the brand orange for
+	   the same affordance as the default .caButton:hover. Defined per-theme
+	   so individual themes can tweak later without disturbing the default
+	   contract. */
+	--ca-button-red: #cc1f1f;
+	--ca-button-red-hover: var(--unraid-66-color);
+	/* Blue-button palette (.actionsInstall and any future install-family
+	   button). Hover lifts to the brand orange for the same affordance
+	   as the default .caButton:hover. */
+	--ca-button-blue: #2870c3;
+	--ca-button-blue-hover: var(--unraid-66-color);
+	/* Green-button palette (.actionsUpdate). Same hover contract as
+	   the blue/red variants — lifts to brand orange. */
+	--ca-button-green: #2ca22c;
+	--ca-button-green-hover: var(--unraid-66-color);
 	--ca-legacy-background-color: var(--background-color,#1d1b1b);
 	--ca-search-modal-background: gray;
 	--search-area-top: 4rem;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/gray.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/gray.css
@@ -15,6 +15,22 @@
 		--support-popup-text: #1b1d1b;
 		--support-popup-background: #ffffff;
 		--unraid-66-color: var(--orange-500,#FF8C2F);
+		/* Red-button palette (.caButtonRed). Base is a strong, readable close-
+		   action red shared across themes; hover lifts to the brand orange for
+		   the same affordance as the default .caButton:hover. Defined per-
+		   theme so individual themes can tweak later without disturbing the
+		   default contract. */
+		--ca-button-red: #cc1f1f;
+		--ca-button-red-hover: var(--unraid-66-color);
+		/* Blue-button palette (.actionsInstall and any future install-family
+		   button). Hover lifts to the brand orange for the same affordance
+		   as the default .caButton:hover. */
+		--ca-button-blue: #2870c3;
+		--ca-button-blue-hover: var(--unraid-66-color);
+		/* Green-button palette (.actionsUpdate). Same hover contract as
+		   the blue/red variants — lifts to brand orange. */
+		--ca-button-green: #2ca22c;
+		--ca-button-green-hover: var(--unraid-66-color);
 		--ca-legacy-background-color: var(--background-color,#1d1b1b);
 		--ca-search-modal-background: var(--ca-legacy-background-color);
 		--search-area-top: 0;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/white.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/white.css
@@ -15,6 +15,22 @@
 	--support-popup-text: #f2f2f2;
 	--support-popup-background: #1c1b1b;
 	--unraid-66-color: var(--orange-500,#FF8C2F);
+	/* Red-button palette (.caButtonRed). Base is a strong, readable close-
+	   action red shared across themes; hover lifts to the brand orange for
+	   the same affordance as the default .caButton:hover. Defined per-theme
+	   so individual themes can tweak later without disturbing the default
+	   contract. */
+	--ca-button-red: #cc1f1f;
+	--ca-button-red-hover: var(--unraid-66-color);
+	/* Blue-button palette (.actionsInstall and any future install-family
+	   button). Hover lifts to the brand orange for the same affordance
+	   as the default .caButton:hover. */
+	--ca-button-blue: #2870c3;
+	--ca-button-blue-hover: var(--unraid-66-color);
+	/* Green-button palette (.actionsUpdate). Same hover contract as
+	   the blue/red variants — lifts to brand orange. */
+	--ca-button-green: #2ca22c;
+	--ca-button-green-hover: var(--unraid-66-color);
 	--ca-legacy-background-color: var(--background-color,#f2f2f2);
 	--ca-search-modal-background: var(--ca-legacy-background-color);
 	--search-area-top: 4rem;
@@ -29,9 +45,13 @@
 	/* Awesomplete <mark> highlight color in suggestion chips */
 	--ca-suggestion-mark-color: var(--ca-hsl-yellow, hsl(65, 100%, 50%));
 }
-.Theme--white .magnificPopup.caButton {
+/* White theme inverts the MFP close pill so the otherwise-light styling
+   stays readable against the dark MFP scrim. The :not(.caButtonRed) guard
+   skips this for the red variant — a red→cyan invert would defeat the
+   whole point of explicitly choosing a red close affordance. */
+.Theme--white .magnificPopup.caButton:not(.caButtonRed) {
 	filter: invert(100%);
 }
-.Theme--white .magnificPopup.caButton:hover {
+.Theme--white .magnificPopup.caButton:not(.caButtonRed):hover {
 	filter: invert(0);
 }


### PR DESCRIPTION
## Summary

Refactors the sidebar's relocated action row so primary install / update / destructive actions are visually distinct from secondary buttons. Colors, icons, and left/right alignment are now driven from action-specific classes (`.actionsInstall` / `.actionsUpdate` / `.actionsUninstall`) added in `skin.php`, with three new themable color palettes.

| Group | Position | Color | Icon | Selector |
|---|---|---|---|---|
| Install / Reinstall / Install second | Right | Blue | fa-download | `.actionsInstall` |
| Update | Right | Green | fa-arrow-circle-o-down | `.actionsUpdate` |
| Uninstall / Remove | Right | Red | fa-times | `.actionsUninstall` |
| WebUI / TS WebUI / Edit / Read Me First / etc. | Left | (default) | per-action via `$context['icon']` | `.caButton.actionsPopup` |
| Pin | Left | (default) | fa-thumb-tack | `.pinPopup` |
| CLOSE / dev-diff CLOSE | (own slot) | Red | fa-times | `.popUpClose` / `.caDiffClose` |
| BACK | (own slot) | (default) | fa-arrow-left | `.popUpBack` / `.popUpStat` |
| MFP CLOSE | top-right fixed | Red | — | `.mfp-close.caButton` + utility classes |

## Theme palette (`themes/*.css`)

Three new var pairs added to every theme, same value across all four so the brand colors are consistent. Defined per-theme so individual themes can tweak later without disturbing the default contract.

```css
--ca-button-red   / --ca-button-red-hover    (#cc1f1f / unraid-66)
--ca-button-blue  / --ca-button-blue-hover   (#2870c3 / unraid-66)
--ca-button-green / --ca-button-green-hover  (#2ca22c / unraid-66)
```

All three hovers lift to `var(--unraid-66-color)`, matching the default `.caButton:hover` affordance.

## Layout (CSS)

- **Right-group push** uses the `margin-left: auto` flex trick on `.actionsInstall.caButton, .actionsUpdate.caButton, .actionsUninstall.caButton`. Only the first right-group item in DOM order keeps the auto-margin; the `~` sibling combinator strips it from subsequent right-group items so they sit packed with the container's normal column-gap (matching the left-group spacing). Selector includes `.caButton` (0,3,0) to outrank the existing `.popupStickyActions > .caButton { margin: 0 }` reset further down in the file.
- **`.popupStickyActions`** now has `flex-grow: 1` (so the auto-margin has slack to eat) and `padding-right: 2rem` so the rightmost button ends the same distance from the sidebar edge as CLOSE does from the left.
- **Pipe separator** added as `::before` on `.popupStickyActions`, scoped to `.popupCloseAreaButtons .popupStickyActions::before` so it only renders after `caRelocatePopupActions()` has moved the strip into the close area — punctuates the wide column-gap between CLOSE and the first left action button so the spacing reads as deliberate.
- **MFP close button** — `position: fixed; top/right: 1.5rem` so it floats in a consistent spot regardless of MFP content type (image vs iframe) or scroll position. The per-holder size/color rules trimmed — sizing and color now provided by two new reusable utility classes (`.caButtonLarge` and `.caButtonRed`), both used `!important` because utility modifiers must beat the context-specific `.magnificPopup.caButton` styling.

## Icons (CSS-first, PHP-fallback)

- **Buttons with a unique semantic class** get their FontAwesome glyph directly in CSS via `::before` — no markup change, no class threading. New `::before` rules added for `.popUpClose`, `.popUpBack`, `.popUpStat`, `.caDiffClose`, `.pinPopup`, `.actionsInstall`, `.actionsUpdate`, `.actionsUninstall`.
- **Left-group action items** (Edit / WebUI / TS WebUI / per-feed actions) all share `.caButton.actionsPopup` with no per-action selector, so their icon class continues to thread from `$context['icon']` (already populated by `skin_helpers.php` for every entry in `$actionsContext`).
- Icon-text gap: `margin-right: 0.5rem` on a scoped `::before` selector set. No-op on icon-less buttons since `::before` only renders when `content` is set.
- Block comment in the markup documents the two-path rationale so future contributors don't accidentally invent a third pattern.

## PHP refactor (`skin.php`)

`$actionsButtonItems` is now partitioned into `$leftActionItems` / `$rightInstallActionItems` / `$rightUpdateActionItems` / `$rightUninstallActionItems` based on `strip_tags`-stripped text. Markup emits the four groups in order so the CSS auto-margin push can right-align the right group as one contiguous block. Detection accepts both `tr()`-localized text and the untranslated English variants so it survives a partial locale file.

## Action label renames

- `"Install second instance"` → `"Install second"` (skin_helpers.php × 4, skin.php detection list updated to match).
- `"Tailscale WebUI"` → `"TS WebUI"` (skin_helpers.php × 2). Stays in the left group since it isn't classified as the `popupShortcut` (only literal `"WebUI"` / `"Settings"` trigger that hoisting).

## White-theme invert filter

`.Theme--white .magnificPopup.caButton`'s `filter: invert(100%)` is now scoped with `:not(.caButtonRed)` so the explicitly-chosen red MFP close button doesn't get inverted to cyan on the white theme.

## Files

- `Apps.page` — MFP `closeMarkup` strings extended with `caButtonLarge caButtonRed`.
- `skins/Narrow/skin.php` — action partitioning + four-group markup, install-family / update / uninstall detection lists, install-second label match.
- `skins/Narrow/skin_helpers.php` — `"Install second instance"` → `"Install second"`, `"Tailscale WebUI"` → `"TS WebUI"`.
- `skins/Narrow/styles/community.applications.css` — utility classes, action-row colors + icons + auto-margin push + padding-right, pipe separator, MFP-close trim.
- `skins/Narrow/themes/{azure,black,gray,white}.css` — three new var pairs; white theme's invert filter scoped with `:not(.caButtonRed)`.

No `.plg` bump. No `ca.md5` touch.

## Test plan

- [ ] **Sidebar action row** — open a Docker app sidebar; confirm Install / Update / Reinstall / Install second / Uninstall buttons render in their respective colors with icons, right-aligned, packed together with normal spacing.
- [ ] Same for plugin sidebars — Update / Uninstall / Edit etc.
- [ ] **Left group** stays where it is (WebUI, Edit, Pin, Read Me First, TS WebUI) with their existing per-action icons; Pin shows a thumb-tack.
- [ ] **Pipe separator** appears between CLOSE and the first left button, sized to roughly match CLOSE.
- [ ] **CLOSE / BACK** — red CLOSE, default BACK; both with their fa-times / fa-arrow-left icons.
- [ ] **MFP close** — open a screenshot from a sidebar; the CLOSE button floats top-right (1.5rem inset), large, red, fa-times-style label.
- [ ] **All four themes** — azure / black / gray / white — colors render correctly; white theme's MFP close stays red (not cyan-inverted).
- [ ] **Mobile / narrow viewport** — action row wraps with right group still right-aligned on its row.
- [ ] **`"Install second"` / `"TS WebUI"`** labels appear with the new shortened text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Restyled popup/gallery close buttons to be larger, red, and more visually prominent; repositioned for fixed top-right placement.
  * Reorganized popup action buttons into left (secondary) and right (install/update/uninstall) groups for clearer alignment and hierarchy.
  * Shortened UI labels ("Tailscale WebUI" → "TS WebUI"; "Install second instance" → "Install second").
  * Added theme-consistent button color palette and reusable button modifier styles.

* **Documentation**
  * Changelog updated with these UI changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->