### PR TITLE
docs: backfill CHANGES.md with user-visible changes since PR #50

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,15 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Added: "Autoplay videos" setting (Settings panel, default off) — controls whether YouTube / Vimeo videos in the sidebar's screenshot gallery start playing automatically when opened
+- Fixed: First tap on a sidebar button or video thumbnail now registers immediately — most visible on mobile, where the first tap used to be wasted "waking up" the sidebar
+- Fixed: Closing a screenshot or video popup now returns the sidebar to the originating app instead of falling through to whichever app happened to be first in the list
+- Fixed: The "Choose A Branch To Install" picker no longer closes the sidebar — it now floats over the sidebar the same way the port-conflict prompt does, and the sidebar stays put whether you pick a branch or cancel
+- Fixed: README and changelog content in the sidebar loads reliably for repos hosted on sites without permissive CORS headers — the fetch now goes through the Unraid backend
+- Fixed: Clicking the Home button consistently returns to the Apps view
+- Fixed: Card flag badges (incompatible / deprecated / blacklisted) render reliably again
+- Changed: Sidebar / scroll / search / category state now stored per-tab in sessionStorage instead of cookies — each browser tab tracks its own state without interfering with other tabs, and the sidebar is restored to the same app you had open when returning to the Apps page
+- Chore: Plugin cache is no longer rewritten on every load when nothing has changed
 - Fixed: Closed a stored-XSS path in the sidebar popup's Install / Update buttons — a hostile maintainer publishing a template with a crafted `RequiresFile` value could otherwise execute arbitrary JS in the user's Unraid GUI session when the user clicked the button
 - Changed: Icon, screenshot, README, and changelog image URLs now reject private-network hosts (RFC1918, link-local, CGNAT, IPv6 ULA, plus `.local` / `.internal` / `.lan` mDNS-style hostnames) — closes a CSRF surface where an auto-loaded image could fire a request at a device on the user's LAN
 - Added: `referrerpolicy='no-referrer'` on every template-supplied image (popup icon, card icon, screenshots, video thumbnails, licence, README / changelog images) so a third-party host doesn't see the user's Unraid URL on each render


### PR DESCRIPTION
## Summary

Backfills `plugins/CHANGES.md` with one-line user-facing bullets for every PR that landed user-visible behaviour between PR #50 (last CHANGES update) and PR #63. Bullets follow the existing format so the block can be copy-pasted into the `<CHANGES>` entity in `community.applications.plg` at release time.

## Bullets added (newest first within the section)

- **Added: "Autoplay videos" setting** — covers PR #62's autoplay toggle.
- **Fixed: first tap on sidebar buttons / videos registers immediately** — covers PR #63's focus-on-open fix (most visible on mobile).
- **Fixed: closing a screenshot/video popup returns the sidebar to the originating app** — covers PR #62's MFP `closeSidebar` `keepIdentity` fix.
- **Fixed: branch-install picker no longer closes the sidebar** — covers PR #62's `displayTags` simplification.
- **Fixed: README/changelog content loads reliably for repos without permissive CORS** — covers PR #55's server-side sidebar fetch route.
- **Fixed: Home button consistently returns to Apps view** — covers PR #54.
- **Fixed: card flag badges render reliably again** — covers PR #52.
- **Changed: sidebar/scroll/search/category state stored per-tab in sessionStorage** — covers PRs #59/#60/#61 (the original sessionStorage refactor, its revert, and the re-roll). One bullet for the net user-facing result.
- **Chore: plugin cache no longer rewritten on every load when nothing changed** — covers PR #51.

## Skipped (no user-perceptible effect)

- #53 / #57 — `chore/alpha-release-*` version bumps.
- #56 — `refactor/dev-mode-raw-feed-snapshot` (dev-mode internals only).
- #58 — `chore/caDebug-and-quiet-attr-cache` (debug-line quieting).

## Notes

- No `.plg` bump — `plugins/CHANGES.md` is the running unreleased log; the `<CHANGES>` entity in `community.applications.plg` stays untouched per standing instruction.
- No source changes — pure documentation PR.
- PR #64 (sidebar action button restyle, currently in review) will add its own bullet in that branch rather than here, since it's not yet merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added autoplay videos setting
  * State storage now uses per-tab sessionStorage instead of cookies

* **Bug Fixes**
  * Fixed sidebar and video popup behavior
  * Fixed initial tap handling
  * Branch picker no longer closes sidebar
  * Improved README/changelog loading for restricted CORS environments
  * More consistent Home-button navigation
  * Restored card flag badge rendering

* **Chores**
  * Plugin cache optimization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->