### PR TITLE
chore: drop dead ca_red span wrappers from action labels

### DIFF
--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -478,10 +478,9 @@ function displayPopup($template) {
 	   far edge, which requires the DOM order to be LEFT first then RIGHT
 	   — render the three buckets in sequence below in .popupStickyActions.
 
-	   Matching on `strip_tags`-stripped text because some labels arrive
-	   wrapped in <span class='ca_red'> (eg. plugin "Remove", "Reinstall
-	   From Previous Apps") that gets stripped later for visual display
-	   anyway. Also accepts the untranslated English variants so the
+	   Matching on `strip_tags`-stripped text as defense-in-depth against
+	   hostile template feed data — legitimate labels are plain strings
+	   from `tr()`. Also accepts the untranslated English variants so the
 	   detection survives a missing/partial locale file. */
 	$installFamilyTexts = [
 		tr("Install"), tr("Reinstall"),

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -514,7 +514,7 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 					}
 					$actionsContext[] = ["divider"=>true];
 					if ($info[$name]['template']) {
-						$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>"<span class='ca_red'>".tr("Uninstall")."</span>","action"=>"uninstallDocker('".addslashes($info[$name]['template'])."','{$template['Name']}');"];
+						$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>tr("Uninstall"),"action"=>"uninstallDocker('".addslashes($info[$name]['template'])."','{$template['Name']}');"];
 						$template['Installed'] = true;
 					}
 				} elseif (!$template['Blacklist']) {
@@ -524,7 +524,7 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Reinstall"),"action"=>"popupInstallXML('".addslashes($template['InstallPath'])."','user','".portsUsed($userTemplate)."');"];
 							$actionsContext[] = ["divider"=>true];
 						}
-						$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>"<span class='ca_red'>".tr("Remove")."</span>","action"=>"removeApp('{$template['InstallPath']}','{$template['Name']}');"];
+						$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>tr("Remove"),"action"=>"removeApp('{$template['InstallPath']}','{$template['Name']}');"];
 					} else {
 						if (!$template['Blacklist']) {
 							if ($template['Compatible'] || $GLOBALS['caSettings']['hideIncompatible'] !== "true") {
@@ -570,7 +570,7 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 					if (!empty($actionsContext)) {
 						$actionsContext[] = ["divider"=>true];
 					}
-					$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>"<span class='ca_red'>".tr("Uninstall")."</span>","action"=>"uninstallApp('/var/log/plugins/$pluginName','".str_replace(" ","&nbsp;",$template['Name'])."');"];
+					$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>tr("Uninstall"),"action"=>"uninstallApp('/var/log/plugins/$pluginName','".str_replace(" ","&nbsp;",$template['Name'])."');"];
 				}
 			} elseif (!$template['Blacklist']) {
 				if (($template['Compatible'] || $GLOBALS['caSettings']['hideIncompatible'] !== "true") && !($template['UninstallOnly'] ?? false)) {
@@ -609,7 +609,7 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 					if (!empty($actionsContext)) {
 						$actionsContext[] = ["divider"=>true];
 					}
-					$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>"<span class='ca_red'>".tr("Remove")."</span>","action"=>"removeApp('{$template['InstallPath']}','$pluginName');"];
+					$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>tr("Remove"),"action"=>"removeApp('{$template['InstallPath']}','$pluginName');"];
 				}
 			}
 			if (is_file(CA_PATHS['pluginPending'].$pluginName)) {
@@ -662,7 +662,7 @@ function caBuildLanguageActions(array &$template, ?string $countryCode, array $a
 				if (!empty($actionsContext)) {
 					$actionsContext[] = ["divider"=>true];
 				}
-				$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>"<span class='ca_red'>".tr("Uninstall")."</span>","action"=>"removeLanguage('$countryCode');"];
+				$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>tr("Uninstall"),"action"=>"removeLanguage('$countryCode');"];
 			}
 		}
 
@@ -874,7 +874,7 @@ function caProcessDockerTemplate(array $template, array $info, array $dockerUpda
 						$test = readXmlFile($previousTemplatePath, true);
 						if ($template['Repository'] == $test['Repository']) {
 							$userTemplate = readXmlFile($previousTemplatePath, false, false);
-							$actionsContext[] = ["icon" => "ca_fa-install", "text" => "<span class='ca_red'>".tr("Reinstall From Previous Apps")."</span>", "action" => "popupInstallXML('".addslashes($previousTemplatePath)."','user','".portsUsed($userTemplate)."');"];
+							$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Reinstall From Previous Apps"), "action" => "popupInstallXML('".addslashes($previousTemplatePath)."','user','".portsUsed($userTemplate)."');"];
 							$actionsContext[] = ["divider" => true];
 						}
 					}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -166,10 +166,6 @@ a {
 	font-size: 1.4rem !important;
 }
 
-.ca_red {
-	color: var(--ca-red-color);
-}
-
 .ca_green {
 	color: var(--ca-green-color);
 }


### PR DESCRIPTION
## Summary

Cleanup that missed the merge window for PR #64 (sidebar action button restyle). The `ca_red` class was used to color destructive action labels (Uninstall / Remove / Reinstall From Previous Apps) in the old action-dropdown menu — that menu doesn't exist anymore, destructive actions now get their color from the `.actionsUninstall` rule applied to the whole button. The PHP-side `<span class='ca_red'>` wrappers and the `.ca_red` CSS rule were both dead code.

## Changes

- **`skin_helpers.php`** — 6 occurrences of `"<span class='ca_red'>".tr("...")."</span>"` reduced to plain `tr("...")`:
  - Uninstall × 3 (docker / plugin / language uninstall actions)
  - Remove × 2 (docker / plugin remove actions)
  - "Reinstall From Previous Apps" × 1
- **`community.applications.css`** — `.ca_red { color: var(--ca-red-color) }` rule deleted. No remaining references anywhere in the codebase (the three remaining `ca_red` substring hits are all `ca_reddit`, the Reddit support icon).
- **`skin.php`** — stale block comment about labels arriving "wrapped in `<span class='ca_red'>`" updated. The `htmlspecialchars(trim(strip_tags((string)$text)), ENT_QUOTES)` defensive pipe added in PR #64's CR-fix commit stays as-is — still useful against hostile feed data even when legitimate labels are now plain strings from `tr()`.

## Notes

- No CHANGES.md bullet — pure refactor / chore with zero user-visible behavior change (the spans had no styling once their class was stripped at render time anyway).
- No `.plg` bump, no `ca.md5` touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)