### PR TITLE
Feat: download smaller feed, lazy load full feed

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,12 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: Initial application-feed download now grabs a slimmed-down feed (no Config blocks) for a faster first paint — the full feed loads in the background so install-time port-conflict detection is ready by the time the user clicks Install
+- Changed: If the primary application feed is unreachable, CA now falls back to a slim copy hosted on GitHub instead of pulling the full feed as a second try
+- Fixed: Reloading Apps without a feed update no longer rewrites the small templates cache with the full-cache contents
+- Fixed: The tab that triggered a feed refresh no longer surfaces its own "another instance updated the feed" reload banner — the publish now carries the originating tab's id and the subscriber skips messages it sent itself
+- Fixed: CA's search-modal autocomplete styling no longer leaks onto other Unraid plugins' awesomplete dropdowns elsewhere on the page
+- Changed: Developer-mode template Diff button now passes the template URL straight to the server instead of looking it up by Path — drops two huge in-memory copies of the templates array and keeps the diff under PHP's 256M memory limit on large feeds
 - Added: "Use whole display window" setting (Settings panel, default off, 7.2+ only) — reclaims the Unraid OS header strip so the app browsing area fills the full browser window
 - Changed: Top bar buttons (Menu / Search / Sort / Apps / DockerHub) now carry FontAwesome icons; on narrow viewports they collapse to icon-only to free horizontal room
 - Changed: Sort button shortened from "Sort By: <selection>" to just "Sort" with a sort icon — the active sort is already highlighted in the icon row beneath it

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -686,6 +686,12 @@ $(function(){
 					showSidebarApp(caSavedState.sidebarAppPath, caSavedState.sidebarAppName);
 				}
 			<? endif;?>
+			/* Restore path doesn't go through updateContent → downloadStatistics,
+			   so kick off downloadStatistics() directly. Beyond fetching stats,
+			   this is what arms the ca_gettingTemplates subscriber — without it
+			   a restored tab would never see the "another instance updated the
+			   feed" reload banner. */
+			downloadStatistics();
 		} else {
 			post({action:"defaultSortOrder"},function() {
 				myAlert("","<div class='ca_center caLogoIcon'></div><?tr('Community Applications');?><br><br><?tr('Updating Applications');?><br><span class='updateContent-swal'>"+tr('Please Wait')+"</span><div class='caDownloadProgress ca_hide'><span class='caDownloadProgressText'></span><div class='caButton ca_quitUpdate'>"+tr('Abort')+"</div></div>","","",false,false,false,"");

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -534,18 +534,17 @@ $(function(){
 	});
 	downloadProgress.start();
 
-	// Start this subscriber only after the initial force_update has completed
-	// (we start it lazily from downloadStatistics()) so the tab doing the update
-	// never reloads itself, but other open CA tabs will.
+	/* Subscribe but defer the .start() until downloadStatistics() runs so the
+	   tab doing the initial force_update doesn't connect early and pile up
+	   spurious connect events. Messages are filtered by tab id: signalFeedReady
+	   publishes the originating tab's data.tabId so the tab that triggered the
+	   update skips its own message — only foreign tabs surface the banner. */
 	window.caGettingTemplatesSubStarted = false;
-	window.caGettingTemplatesSubIgnoreFirst = true;
 	window.caGettingTemplatesSub = new NchanSubscriber('/sub/ca_gettingTemplates',{subscriber:'websocket'});
 	window.caGettingTemplatesSub.on('message', function(message) {
-		if (window.caGettingTemplatesSubIgnoreFirst) {
-			window.caGettingTemplatesSubIgnoreFirst = false;
-			return;
-		}
 		if ( ! message ) return;
+		// Originating tab id from the server — skip if it's us.
+		if (data && data.tabId && message === data.tabId) return;
 		/* If a plugin / docker install (or any Unraid openPlugin / openDocker
 		   dialog) is currently on screen, hold the "another session updated
 		   the feed" notice until it's done — otherwise the viewport blocker
@@ -788,6 +787,13 @@ function updateContent(button,skipAppfeed=true) {
 				getContent(true,'INITIALIZE',"","",startupScreen);
 			}
 		}
+		/* If the initial download used the slim feed, the full templates
+		   cache is empty — kick off a background hydrate so install-time
+		   port-conflict detection and createXML have Config available by
+		   the time the user clicks Install. Server short-circuits with
+		   `already_fresh` when the full cache is already on disk, so this
+		   is safe to call unconditionally. */
+		postNoSpin({action:'hydrateFullFeed'});
 		getCategories(); /* now also re-applies count-based submenu gating */
 		if ( $.cookie("ca_plugininstallpending" || ! button ) ) {
 			var plugins = $.cookie("ca_plugininstallpending");
@@ -1126,7 +1132,6 @@ function getContent(init,category,description,newApp,startupDisplay) {
 function downloadStatistics() {
 	try {
 		if (window.caGettingTemplatesSub && !window.caGettingTemplatesSubStarted) {
-			window.caGettingTemplatesSubIgnoreFirst = true;
 			window.caGettingTemplatesSub.start();
 			window.caGettingTemplatesSubStarted = true;
 		}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/diff.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/diff.php
@@ -39,11 +39,11 @@ function getTemplateDiff() {
 		postReturn(["ok"=>false, "message"=>tr("Dev mode is not enabled")]);
 		return;
 	}
-	$appPath = trim((string)getPost("appPath", ""));
-	$mode    = trim((string)getPost("mode", "feed"));
+	$templateUrl = trim((string)getPost("templateUrl", ""));
+	$mode        = trim((string)getPost("mode", "feed"));
 	if ($mode !== "feed" && $mode !== "internal") $mode = "feed";
-	if ($appPath === "") {
-		postReturn(["ok"=>false, "message"=>tr("Missing app path")]);
+	if ($templateUrl === "") {
+		postReturn(["ok"=>false, "message"=>tr("Missing template URL")]);
 		return;
 	}
 	/* Internal mode is gated by the admin marker file — both client and server
@@ -53,58 +53,36 @@ function getTemplateDiff() {
 		return;
 	}
 
-	/* The slim templates cache (loaded by getGlobals() at request start) is
-	   enough to find the entry's TemplateURL / PluginURL — used to match
-	   against the freshly-downloaded applicationFeed.json. */
-	$templates = $GLOBALS['templates'] ?? [];
-	if (!is_array($templates) || !$templates) {
-		postReturn(["ok"=>false, "message"=>tr("Appfeed not available")]);
-		return;
-	}
-	$localEntry = null;
-	foreach ($templates as $t) {
-		if (!is_array($t)) continue;
-		if (($t['Path'] ?? null) === $appPath || ($t['InstallPath'] ?? null) === $appPath) {
-			$localEntry = $t;
-			break;
-		}
-	}
-	if (!$localEntry) {
-		postReturn(["ok"=>false, "message"=>tr("App not found in appfeed")]);
-		return;
-	}
+	/* The slim templates cache loaded by getGlobals() at request start gives
+	   us nothing — we already know the URL of the app from the button's POST.
+	   Drop it before reading the raw feed snapshot so peak memory stays
+	   bounded to one huge array at a time. */
+	unset($GLOBALS['templates']);
 
-	$isPlugin   = !empty($localEntry['Plugin']);
-	$matchField = $isPlugin ? "PluginURL" : "TemplateURL";
-	$matchUrl   = (string)($localEntry[$matchField] ?? "");
-	if ($matchUrl === "") {
-		postReturn(["ok"=>false, "message"=>tr("No {$matchField} available for this app")]);
-		return;
-	}
-
-	/* Both modes need the appfeed entry — read the raw snapshot stashed by
-	   DownloadApplicationFeed() when dev mode is on, and locate the matching
-	   entry by TemplateURL / PluginURL. Snapshot is rewritten on every feed
-	   refresh; cold start (dev mode just enabled) returns null. */
-	$applicationFeed = caGetCachedApplicationFeed();
-	if (!is_array($applicationFeed)) {
+	/* Look the entry up directly in the raw appfeed snapshot
+	   (DownloadApplicationFeed / hydrateFullFeed write this in dev mode).
+	   Search by TemplateURL first, then PluginURL — the button passes
+	   whichever the source app carries. */
+	$rawFeed = readJsonFile(CA_PATHS['rawAppFeed']);
+	if (!is_array($rawFeed['applist'] ?? null) || empty($rawFeed['applist'])) {
 		postReturn(["ok"=>false, "message"=>tr("Application feed snapshot not available — refresh the application feed first")]);
 		return;
 	}
-	$appfeedEntry = null;
-	foreach ($applicationFeed['applist'] as $candidate) {
-		if (!is_array($candidate)) continue;
-		if ((string)($candidate[$matchField] ?? "") === $matchUrl) {
-			$appfeedEntry = $candidate;
-			break;
-		}
+	$idx = searchArray($rawFeed['applist'], 'TemplateURL', $templateUrl);
+	if ($idx === false) {
+		$idx = searchArray($rawFeed['applist'], 'PluginURL', $templateUrl);
 	}
-	if (!$appfeedEntry) {
+	if ($idx === false) {
 		postReturn(["ok"=>false, "message"=>tr("Could not find this app in the downloaded application feed")]);
 		return;
 	}
+	$appfeedEntry = $rawFeed['applist'][$idx];
+	/* Free the raw appfeed — we only need the one entry from here on. */
+	unset($rawFeed);
 
-	$appName = (string)($localEntry['Name'] ?? "");
+	$isPlugin = !empty($appfeedEntry['Plugin']);
+	$matchUrl = $templateUrl;
+	$appName  = (string)($appfeedEntry['Name'] ?? "");
 	$rootName = $isPlugin ? "PLUGIN" : "Container";
 
 	if ($mode === "feed") {
@@ -157,21 +135,19 @@ function getTemplateDiff() {
 		   LEFT  = appfeed entry (server's view)
 		   RIGHT = CA's internal templates_full.json entry, reordered to the
 		           appfeed's key order so the CA-pipeline additions surface at
-		           the bottom of the right column. */
+		           the bottom of the right column.
+		   Now we need the full templates cache — find the entry by the same
+		   URL, extract it, then drop the big array so it doesn't sit in
+		   memory alongside the eventual diff output. */
 		getFullGlobals();
-		$fullTemplates = $GLOBALS['templates'] ?? [];
-		$internalEntry = null;
-		foreach ($fullTemplates as $t) {
-			if (!is_array($t)) continue;
-			if (($t['Path'] ?? null) === $appPath || ($t['InstallPath'] ?? null) === $appPath) {
-				$internalEntry = $t;
-				break;
-			}
-		}
-		if (!$internalEntry) {
+		$matchField = $isPlugin ? 'PluginURL' : 'TemplateURL';
+		$idx = searchArray($GLOBALS['templates'], $matchField, $matchUrl);
+		if ($idx === false) {
 			postReturn(["ok"=>false, "message"=>tr("App not found in internal templates cache")]);
 			return;
 		}
+		$internalEntry = $GLOBALS['templates'][$idx];
+		unset($GLOBALS['templates']);
 		$leftArr    = $appfeedEntry;
 		$rightArr   = caReorderByReference($internalEntry, $appfeedEntry);
 		$leftLabel  = htmlspecialchars(tr("appfeed"), ENT_QUOTES);
@@ -228,7 +204,7 @@ function caRenderAsJson(array $entry): string {
 /**
  * Read the raw applicationFeed.json snapshot that DownloadApplicationFeed()
  * stashes whenever dev mode is enabled (exec.php — the `@copy($downloadURL,
- * CA_PATHS['diffFeedCache'])` line just before the per-request tempfile is
+ * CA_PATHS['rawAppFeed'])` line just before the per-request tempfile is
  * unlinked). Returns the decoded array on success or null on any failure.
  *
  * No download / no flock: the file is rewritten on every feed refresh so in
@@ -237,7 +213,7 @@ function caRenderAsJson(array $entry): string {
  * "Could not download application feed", which is the cue to refresh.
  */
 function caGetCachedApplicationFeed(): ?array {
-	$cachePath = CA_PATHS['diffFeedCache'];
+	$cachePath = CA_PATHS['rawAppFeed'];
 	if (!is_file($cachePath)) return null;
 	$decoded = json_decode((string)@file_get_contents($cachePath), true);
 	/* Require a non-empty applist — same shape DownloadApplicationFeed

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -292,6 +292,13 @@ function DownloadApplicationFeed() {
 		if ( ! is_array($ApplicationFeed['applist'] ?? null) || empty($ApplicationFeed['applist']) ) {
 			return false;
 		}
+		/* Local feed IS the full applicationFeed.json (no slim/full split in
+		   localONLY mode), so stash it as the raw-feed snapshot for the
+		   dev-mode Diff button. Mirrors the @copy in hydrateFullFeedWork's
+		   remote path — without it, dev-mode diff is unreachable in localONLY. */
+		if ( ($GLOBALS['caSettings']['dev'] ?? null) === "yes" ) {
+			@copy(CA_PATHS['application-feed-local'], CA_PATHS['rawAppFeed']);
+		}
 		return processApplicationFeed($ApplicationFeed, "Local") ? 'slim' : false;
 	}
 
@@ -572,16 +579,29 @@ function processApplicationFeed(array $ApplicationFeed, string $currentFeed): bo
  */
 function hydrateFullFeedWork(): string {
 	clearstatcache();
+	$devMode = ($GLOBALS['caSettings']['dev'] ?? null) === "yes";
 	/* tempFiles gets wiped on every DownloadApplicationFeed() entry, so the
 	   full cache file's mere existence means it was written by either a
 	   full-feed download or a prior hydrate — no stale state to worry about. */
 	if ( is_file(CA_PATHS['community-templates-info-full']) ) {
+		/* Backfill the dev-mode raw-feed snapshot in localONLY mode if dev
+		   mode got toggled on after the prior hydrate wrote the full cache
+		   without it. Cheap file copy — keeps the Diff button reachable
+		   without forcing a redownload. */
+		if ( CA_PATHS['localONLY'] && $devMode && ! is_file(CA_PATHS['rawAppFeed']) ) {
+			@copy(CA_PATHS['application-feed-local'], CA_PATHS['rawAppFeed']);
+		}
 		return 'already_fresh';
 	}
 
 	if ( CA_PATHS['localONLY'] ) {
 		$ApplicationFeed = json_decode(file_get_contents(CA_PATHS['application-feed-local']), true);
 		$label = "Local (hydrate)";
+		/* Stash the local feed as the raw-feed snapshot for the dev-mode
+		   Diff button — same intent as the remote-path @copy below. */
+		if ( $devMode && is_array($ApplicationFeed['applist'] ?? null) && ! empty($ApplicationFeed['applist']) ) {
+			@copy(CA_PATHS['application-feed-local'], CA_PATHS['rawAppFeed']);
+		}
 	} else {
 		$downloadURL = randomFile();
 		$ApplicationFeed = download_json(CA_PATHS['application-feed'], $downloadURL, 600, false);
@@ -596,8 +616,7 @@ function hydrateFullFeedWork(): string {
 		   DownloadApplicationFeed() never produced this cache (it grabs
 		   the slimmed-down file), so the full-feed hydrate is the
 		   responsible writer in the slim-first path. */
-		if ( is_array($ApplicationFeed['applist'] ?? null) && ! empty($ApplicationFeed['applist'])
-		     && ($GLOBALS['caSettings']['dev'] ?? null) === "yes" ) {
+		if ( is_array($ApplicationFeed['applist'] ?? null) && ! empty($ApplicationFeed['applist']) && $devMode ) {
 			@copy($downloadURL, CA_PATHS['rawAppFeed']);
 		}
 		@unlink($downloadURL);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -97,6 +97,9 @@ switch ($_POST['action']) {
 		caRequireSkin();
 		get_content();
 		break;
+	case 'hydrateFullFeed':
+		hydrateFullFeed();
+		break;
 	case 'force_update':
 		force_update();
 		break;
@@ -264,7 +267,19 @@ switch ($_POST['action']) {
 /**
  * Download and merge the application feed into local template caches.
  *
+ * Initial-load is slim only — tries `applicationFeed-small.json` on the
+ * primary server, then on the GitHub backup. If both fail the user sees
+ * the standard download-failed response; we never fall back to the full
+ * `applicationFeed.json` here. The full feed is fetched asynchronously by
+ * the `hydrateFullFeed` action (triggered from JS post-`force_update`),
+ * which fills in the on-disk full cache so install-time port-conflict
+ * detection and createXML have Config available.
+ *
+ * Returns 'slim' on success, false on failure.
+ *
  * DownloadApplicationFeed() must run before community template merge so private repos apply correctly.
+ *
+ * @return false|string
  */
 function DownloadApplicationFeed() {
 	exec("rm -rf ".escapeshellarg(CA_PATHS['tempFiles']));
@@ -272,54 +287,63 @@ function DownloadApplicationFeed() {
 	@unlink(CA_PATHS['downloadLocks']);
 	@mkdir(CA_PATHS['templates-community'],0777,true);
 
-	$currentFeed = "Primary Server";
 	if ( CA_PATHS['localONLY'] ) {
 		$ApplicationFeed = json_decode(file_get_contents(CA_PATHS['application-feed-local']),true);
-	} else {
-		$downloadURL = randomFile();
-		ca_publish("ca_gettingTemplates","1");
-		/* 10-minute cURL timeout (was unbounded) — the ca_downloadProgress
-		   nchan stream lets the user see and Abort a slow fetch, but the
-		   timeout caps the worst case in case the connection silently stalls
-		   without ever timing out at the socket layer.
-		   shared=false: $downloadURL is a per-request random tempfile — we
-		   don't want download_url to serialize different requests on each
-		   other since their target paths are unique anyway. */
-		$ApplicationFeed = download_json(CA_PATHS['application-feed'], $downloadURL, 600, false);
-		if ( (! is_array($ApplicationFeed['applist']??false)) || (empty($ApplicationFeed['applist']??[])) ) {
-			$currentFeed = "Backup Server";
-			$ApplicationFeed = download_json(CA_PATHS['pluginProxy'].CA_PATHS['application-feedBackup'], $downloadURL, 600, false);
-		}
-		/* Null-coalesce — if both primary + backup downloads returned false,
-		   $ApplicationFeed is false here and a direct array-access would
-		   warn before the clean failure path below runs. Mirrors the same
-		   `?? false` / `?? []` pattern used in the primary check at line 255. */
-		if ( ! is_array($ApplicationFeed['applist'] ?? null) || empty($ApplicationFeed['applist'] ?? []) ) {
-			/* Don't unlink $downloadURL on failure — leave the raw bytes
-			   (preserved by download_json under $shared=false) on disk so
-			   buildDownloadFailureResponse can read them for the
-			   partial-download hint + json_last_error_msg detail. */
-			@unlink(CA_PATHS['currentServer']);
-			ca_file_put_contents(CA_PATHS['appFeedDownloadError'],$downloadURL);
+		if ( ! is_array($ApplicationFeed['applist'] ?? null) || empty($ApplicationFeed['applist']) ) {
 			return false;
 		}
-		/* Dev mode: stash the raw applicationFeed.json before deleting the
-		   per-request tempfile so the Diff/Plugin/Template modals don't have
-		   to re-download it. tempFiles was wiped at the top of this function
-		   so the cache file is always fresh; outside dev mode we never write
-		   it, which keeps the steady-state footprint identical for normal
-		   users. caGetCachedApplicationFeed() reads this on every Diff
-		   click. */
-		if (($GLOBALS['caSettings']['dev'] ?? null) === "yes") {
-			@copy($downloadURL, CA_PATHS['diffFeedCache']);
-		}
-		/* Success — feed parsed cleanly, the per-request tempfile served its
-		   purpose. Clean it up so /tmp doesn't accumulate stale randomFile()s. */
-		@unlink($downloadURL);
+		return processApplicationFeed($ApplicationFeed, "Local") ? 'slim' : false;
 	}
+
+	$downloadURL = randomFile();
+	/* ca_gettingTemplates publish (the "other tab updated the feed" trigger)
+	   has moved into writeGlobals via signalFeedReady() — fires when the
+	   small cache lands. The background full-feed hydrate writes only the
+	   full cache and stays silent so it doesn't double-fire. */
+
+	/* Primary slim. 10-minute cURL timeout / shared=false: per-request
+	   tempfile, so we don't want download_url to serialize unrelated calls. */
+	$smallFeed = download_json(CA_PATHS['application-feed-small'], $downloadURL, 600, false);
+	$currentFeed = "Primary Server (slim)";
+	if ( ! is_array($smallFeed['applist'] ?? null) || empty($smallFeed['applist']) ) {
+		/* Primary slim unavailable — try the GitHub backup of the slim feed.
+		   No fallback to the full feed beyond this; if both slim tiers fail
+		   the user gets the standard download-failed response and retries. */
+		$smallFeed = download_json(CA_PATHS['pluginProxy'].CA_PATHS['application-feed-smallBackup'], $downloadURL, 600, false);
+		$currentFeed = "Backup Server (slim)";
+	}
+	if ( ! is_array($smallFeed['applist'] ?? null) || empty($smallFeed['applist']) ) {
+		/* Don't unlink $downloadURL on failure — leave the raw bytes
+		   (preserved by download_json under $shared=false) on disk so
+		   buildDownloadFailureResponse can read them for the
+		   partial-download hint + json_last_error_msg detail. */
+		@unlink(CA_PATHS['currentServer']);
+		ca_file_put_contents(CA_PATHS['appFeedDownloadError'],$downloadURL);
+		return false;
+	}
+	@unlink($downloadURL);
+
+	return processApplicationFeed($smallFeed, $currentFeed) ? 'slim' : false;
+}
+
+/**
+ * Apply CA's per-template transformations to a freshly-downloaded feed and
+ * persist the auxiliary files (categoryList / repositoryList / extraBlacklist
+ * / extraDeprecated / lastUpdated-old / invalidXML / currentServer). Sets
+ * `$GLOBALS['templates']` to the processed array so the caller can run
+ * moderation and writeGlobals afterwards.
+ *
+ * Used by both `DownloadApplicationFeed()` (initial load) and
+ * `hydrateFullFeedWork()` (background full-feed pull after a slim-feed success).
+ *
+ * @param array $ApplicationFeed Decoded JSON: applist, categories, repositories, blacklisted, deprecated, last_updated_timestamp
+ * @param string $currentFeed Label written to currentServer (Primary / Backup / Local / slim)
+ * @return bool
+ */
+function processApplicationFeed(array $ApplicationFeed, string $currentFeed): bool {
 	ca_file_put_contents(CA_PATHS['currentServer'],$currentFeed);
 	$i = 0;
-	$lastUpdated['last_updated_timestamp'] = $ApplicationFeed['last_updated_timestamp'];
+	$lastUpdated['last_updated_timestamp'] = $ApplicationFeed['last_updated_timestamp'] ?? null;
 	writeJsonFile(CA_PATHS['lastUpdated-old'],$lastUpdated);
 
 	/* User-curated ignore list (set in the moderation Repository view) — any
@@ -526,9 +550,86 @@ function DownloadApplicationFeed() {
 	writeJsonFile(CA_PATHS['extraDeprecated'],$ApplicationFeed['deprecated']);
 
 	updatePluginSupport($myTemplates);
-	touch(CA_PATHS['haveTemplates']);
+	/* haveTemplates touch + ca_publish are handled by signalFeedReady()
+	   inside writeGlobals — fires the moment the small cache is on disk
+	   so other tabs can reload, regardless of whether the slim path or
+	   the full-feed fallback ran. The hydrate path writes only the full
+	   cache and stays silent so we don't double-fire. */
 
 	return true;
+}
+
+/**
+ * Inner worker for the background hydrate. Pulls the full `applicationFeed.json`
+ * (primary then GitHub backup), runs the same per-template pipeline
+ * `DownloadApplicationFeed()` runs, applies moderation, and writes both
+ * templates caches so install-time port-conflict detection and createXML
+ * have Config available.
+ *
+ * Returns one of "already_fresh" | "ok" | "failed" without touching the
+ * HTTP response, so it's safe to call from createXML's synchronous
+ * safety-net path as well as from the `hydrateFullFeed` action handler.
+ */
+function hydrateFullFeedWork(): string {
+	clearstatcache();
+	/* tempFiles gets wiped on every DownloadApplicationFeed() entry, so the
+	   full cache file's mere existence means it was written by either a
+	   full-feed download or a prior hydrate — no stale state to worry about. */
+	if ( is_file(CA_PATHS['community-templates-info-full']) ) {
+		return 'already_fresh';
+	}
+
+	if ( CA_PATHS['localONLY'] ) {
+		$ApplicationFeed = json_decode(file_get_contents(CA_PATHS['application-feed-local']), true);
+		$label = "Local (hydrate)";
+	} else {
+		$downloadURL = randomFile();
+		$ApplicationFeed = download_json(CA_PATHS['application-feed'], $downloadURL, 600, false);
+		$label = "Primary Server (hydrate)";
+		if ( (! is_array($ApplicationFeed['applist'] ?? null)) || empty($ApplicationFeed['applist']) ) {
+			$ApplicationFeed = download_json(CA_PATHS['pluginProxy'].CA_PATHS['application-feedBackup'], $downloadURL, 600, false);
+			$label = "Backup Server (hydrate)";
+		}
+		/* Dev mode: stash the raw applicationFeed.json snapshot before
+		   deleting the per-request tempfile so the Diff/Plugin/Template
+		   modals don't have to re-download it. The slim-feed download in
+		   DownloadApplicationFeed() never produced this cache (it grabs
+		   the slimmed-down file), so the full-feed hydrate is the
+		   responsible writer in the slim-first path. */
+		if ( is_array($ApplicationFeed['applist'] ?? null) && ! empty($ApplicationFeed['applist'])
+		     && ($GLOBALS['caSettings']['dev'] ?? null) === "yes" ) {
+			@copy($downloadURL, CA_PATHS['rawAppFeed']);
+		}
+		@unlink($downloadURL);
+	}
+
+	if ( ! is_array($ApplicationFeed['applist'] ?? null) || empty($ApplicationFeed['applist']) ) {
+		return 'failed';
+	}
+
+	if ( ! processApplicationFeed($ApplicationFeed, $label) ) {
+		return 'failed';
+	}
+
+	/* Run moderation on the freshly-downloaded full templates so the
+	   on-disk full cache mirrors what force_update's full-feed branch
+	   would produce. The small cache was already written by the slim
+	   path that preceded us — don't overwrite it here. No feed-ready
+	   signal: that fired when writeGlobals wrote the small cache; the
+	   full-cache hydrate is silent so subscribers don't double-reload. */
+	moderateTemplates();
+	writeJsonFile(CA_PATHS['community-templates-info-full'], $GLOBALS['templates']);
+	return 'ok';
+}
+
+/**
+ * Background hydrate action — wraps hydrateFullFeedWork() with the standard
+ * postReturn payload. Triggered by JS once `force_update` returns success.
+ * Safe to call unconditionally; the worker short-circuits with
+ * "already_fresh" when the full cache is already on disk.
+ */
+function hydrateFullFeed() {
+	postReturn(['status' => hydrateFullFeedWork()]);
 }
 
 /**
@@ -1303,7 +1404,13 @@ function force_update() {
 	}
 	touch(CA_PATHS['gettingTemplates']);
 
-	getFullGlobals();
+	/* Load the slim cache, not the full one — moderateTemplates and
+	   buildUpdateScript only touch fields present in the slim copy, and
+	   writeGlobals at the end writes $GLOBALS['templates'] as-is to the
+	   small cache. Loading the full cache here would make the no-download
+	   path write the full templates (Config and all) back to the small
+	   cache, defeating the whole point of having two caches. */
+	getGlobals();
 
 	if (!empty(CA_PATHS['localONLY'])) {
 		ForceUpdateHelpers::resetTemplatesCache(true);
@@ -1329,10 +1436,13 @@ function force_update() {
 
 	//getConvertedTemplates();
 	moderateTemplates();
-	touch(CA_PATHS['haveTemplates']);
 	@unlink(CA_PATHS['gettingTemplates']);
 	$script = ForceUpdateHelpers::buildUpdateScript();
 
+	/* writeGlobals writes the slim cache (and fires the feed-ready signal).
+	   The full cache is filled in by hydrateFullFeedWork — there is no
+	   full-feed fallback in DownloadApplicationFeed anymore, so nothing
+	   here writes community-templates-info-full directly. */
 	writeGlobals($GLOBALS['templates']);
 	postReturn(['status' => "ok", 'script' => $script]);
 }
@@ -2016,6 +2126,18 @@ function caExtractXmlEntities(string $xml): array {
  * @return void
  */
 function createXML() {
+
+	/* Slim-feed path leaves the full cache absent — only the slim-feed
+	   download wrote the small cache; the full-cache write is deferred
+	   to hydrateFullFeedWork (kicked off by JS) or the fallback full-feed
+	   branch of force_update. If a fast-clicker hits Install before the
+	   background hydrate completes, run hydration synchronously here so
+	   adjustTemplatePorts() and the rest of the install pipeline have
+	   Config + Network. The tempFiles directory is wiped on every feed
+	   refresh, so file existence is a sufficient freshness signal. */
+	if ( ! is_file(CA_PATHS['community-templates-info-full']) ) {
+		hydrateFullFeedWork();
+	}
 
 	getFullGlobals();
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -101,10 +101,40 @@ function writeGlobals($templates) {
 		unset($GLOBALS['templates']);
 		return;
 	}
-	$smallTemplates = duplicateArrayWithoutKeys($templates, ['Config','Network','MyIP','Shell','ExtraParams','PostArgs','CPUset','TailscaleEnabled','TailscaleIsExitNode','TailscaleDParams','TailscaleParams','TailscaleStateDir','TailscaleUserspaceNetworking']);
-	writeJsonFile(CA_PATHS['community-templates-info'],$smallTemplates);
-	writeJsonFile(CA_PATHS['community-templates-info-full'],$templates);
-	$GLOBALS['templates'] = $smallTemplates;
+	/* Write the templates as-is to the small cache — no second-pass strip.
+	   The server's slim feed already arrives without the heavy fields, and
+	   the full-feed fallback path explicitly writes the full cache itself
+	   via writeJsonFile() so we don't reiterate the array here. */
+	writeJsonFile(CA_PATHS['community-templates-info'], $templates);
+	$GLOBALS['templates'] = $templates;
+	/* Feed-ready signal fires here — the slim cache is what the UI reads
+	   for card rendering, so the moment it's on disk other open CA tabs can
+	   safely reload. The background full-feed hydrate only writes the full
+	   cache (via writeJsonFile directly, bypassing writeGlobals), so it
+	   doesn't re-fire the signal — install-time data hydrates silently. */
+	signalFeedReady();
+}
+
+/**
+ * Mark the templates feed as fully ready: touch the haveTemplates sentinel
+ * (gates enableActionCentre's wait loop) and publish on the
+ * `/sub/ca_gettingTemplates` nchan channel so other open CA tabs surface
+ * the reload banner. Should fire ONLY after the full templates cache has
+ * been written — slim-only state must keep this signal absent so background
+ * tabs aren't told the feed is ready before install-time Config data is
+ * actually on disk.
+ *
+ * The publish payload is the originating browser tab's id (from
+ * $_POST['tabId']) so the tab that triggered this update doesn't fire its
+ * own reload banner — the JS subscriber compares to its local tab id and
+ * skips when they match. Falls back to "1" if no tab id is on the request
+ * (e.g. when called from a sync safety-net path that wasn't POSTed by JS),
+ * which makes EVERY subscriber treat it as foreign and reload.
+ */
+function signalFeedReady() {
+	touch(CA_PATHS['haveTemplates']);
+	$originTabId = (string)($_POST['tabId'] ?? "");
+	ca_publish("ca_gettingTemplates", $originTabId !== "" ? $originTabId : "1");
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
@@ -82,12 +82,21 @@ define("CA_PATHS",[
 	'repositoriesDisplayed'               => "$tempFiles/repositoriesDisplayed{$caTabSuffix}.json", /* per-tab */
 	'localONLY'                           => false,    /* THIS MUST NOT BE SET TO TRUE WHEN DOING A RELEASE */
 	'application-feed'                    => "https://ca.unraid.net/assets/feed/applicationFeed.json",
+	/* Slimmed-down feed: same shape as the full feed, just with each template's
+	   Config entries stripped out. Primary-only — GitHub backup serves only the
+	   full feed. CA tries this first for a faster initial render and then
+	   background-hydrates the full feed afterwards. */
+	'application-feed-small'              => "https://ca.unraid.net/assets/feed/applicationFeed-small.json",
 	'application-feed-last-updated'       => "https://ca.unraid.net/assets/feed/applicationFeed-lastUpdated.json",
 	'application-feedBackup'              => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed.json",
+	/* GitHub backup of the slim feed. Both initial-load tiers download
+	   applicationFeed-small.json; if both fail we error out rather than
+	   pulling the full feed as a third try. */
+	'application-feed-smallBackup'        => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed-small.json",
 	'application-feed-last-updatedBackup' => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed-lastUpdated.json",
 	'application-feed-local'              => "/tmp/GitHub/AppFeed/applicationFeed.json",
 	'appFeedDownloadError'                => "$tempFiles/downloaderror.txt",
-	'diffFeedCache'                       => "$tempFiles/applicationFeed-raw.json", /* raw applicationFeed.json snapshot — populated by DownloadApplicationFeed() ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
+	'rawAppFeed'                       => "$tempFiles/applicationFeed-raw.json", /* raw applicationFeed.json snapshot — populated by DownloadApplicationFeed() ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
 	'caAdmin'                             => "/boot/config/plugins/community.applications/admin", /* marker file: when present alongside dev mode, exposes the Internal diff button */
 	'categoryList'                        => "$tempFiles/categoryList.json",
 	'repositoryList'                      => "$tempFiles/repositoryList.json",

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
@@ -96,7 +96,7 @@ define("CA_PATHS",[
 	'application-feed-last-updatedBackup' => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed-lastUpdated.json",
 	'application-feed-local'              => "/tmp/GitHub/AppFeed/applicationFeed.json",
 	'appFeedDownloadError'                => "$tempFiles/downloaderror.txt",
-	'rawAppFeed'                       => "$tempFiles/applicationFeed-raw.json", /* raw applicationFeed.json snapshot — populated by DownloadApplicationFeed() ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
+	'rawAppFeed'                       => "$tempFiles/applicationFeed-raw.json", /* raw applicationFeed.json snapshot — populated by hydrateFullFeedWork() (and the localONLY branch of DownloadApplicationFeed) ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
 	'caAdmin'                             => "/boot/config/plugins/community.applications/admin", /* marker file: when present alongside dev mode, exposes the Internal diff button */
 	'categoryList'                        => "$tempFiles/categoryList.json",
 	'repositoryList'                      => "$tempFiles/repositoryList.json",

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/diff.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/diff.js
@@ -20,10 +20,13 @@
  * Dev-mode Diff button: fetch the unified diff between the appfeed entry and
  * the upstream template/.plg, then render it into the #caDiffView overlay.
  *
- * @param {string} appPath The template Path (matches appfeed Path/InstallPath)
+ * @param {string} templateUrl Template/Plugin URL — used server-side to look up
+ *                             the appfeed entry directly in the raw snapshot,
+ *                             so we don't load any templates cache.
  * @param {string} appName Display name for the dialog title
+ * @param {string} mode    "feed" (default) or "internal"
  */
-function caShowTemplateDiff(appPath, appName, mode) {
+function caShowTemplateDiff(templateUrl, appName, mode) {
 	mode = mode || "feed";
 	var $content = $("#caDiffContent");
 	if (!$content.length) return;
@@ -42,7 +45,7 @@ function caShowTemplateDiff(appPath, appName, mode) {
 	caShowTemplateDiff._seq = (caShowTemplateDiff._seq || 0) + 1;
 	var myReqId = caShowTemplateDiff._seq;
 
-	postNoSpin({ action: "getTemplateDiff", appPath: appPath, mode: mode }, function(result) {
+	postNoSpin({ action: "getTemplateDiff", templateUrl: templateUrl, mode: mode }, function(result) {
 		if (myReqId !== caShowTemplateDiff._seq) return;
 		if ($("#caDiffView").hasClass("ca_hide")) return;
 		$content.empty();

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -287,23 +287,28 @@ function caBuildSupportContext(array $template, array $allRepositories) {
 			$pluginUrlJs = json_encode((string)$template['PluginURL'], $jsFlags);
 			$supportContext[] = ["icon"=>"ca_fa-template","action"=>"caShowDevSource({$pluginUrlJs},true)","text"=>tr("Plugin"), "class"=>"ca_devMode"];
 		}
-		$diffPath = json_encode((string)($template['Path'] ?? ""), $jsFlags);
+		/* Pass the URL straight through to the diff endpoint so it can locate
+		   the appfeed entry without loading any templates cache — saves a
+		   huge memory load. TemplateURL for containers, PluginURL for the
+		   internal-diff button on plugins. */
 		$diffName = json_encode((string)($template['Name'] ?? ""), $jsFlags);
+		$diffContainerUrl = json_encode($templateUrl, $jsFlags);
+		$diffPluginUrl    = json_encode((string)($template['PluginURL'] ?? ""), $jsFlags);
 		/* Both Diff buttons go through caGetCachedApplicationFeed which reads
 		   the raw appfeed snapshot DownloadApplicationFeed() stashes to
-		   diffFeedCache (dev-mode only). Until that file lands on disk the
+		   rawAppFeed (dev-mode only). Until that file lands on disk the
 		   buttons can't do anything useful — hide them entirely rather than
 		   render an option that errors out on click. Handles the edge case
 		   of opening a sidebar before the background feed download finishes
 		   on a slow connection. */
-		$diffFeedReady = is_file(CA_PATHS['diffFeedCache']);
+		$diffFeedReady = is_file(CA_PATHS['rawAppFeed']);
 		/* Diff is container-only — plugin .plg payloads don't survive the
 		   array→XML round-trip cleanly and the resulting diff is more noise
 		   than signal. */
-		if ($diffFeedReady && empty($template['Plugin'])) {
+		if ($diffFeedReady && empty($template['Plugin']) && $templateUrl !== "") {
 			$supportContext[] = [
 				"icon"   => "ca_fa-diff",
-				"action" => "caShowTemplateDiff({$diffPath},{$diffName},'feed')",
+				"action" => "caShowTemplateDiff({$diffContainerUrl},{$diffName},'feed')",
 				"text"   => tr("Diff"),
 				"class"  => "ca_devMode",
 			];
@@ -312,9 +317,10 @@ function caBuildSupportContext(array $template, array $allRepositories) {
 		   when the admin marker file exists. Available for plugins too since
 		   neither side does a source-XML round-trip. */
 		if ($diffFeedReady && is_file(CA_PATHS['caAdmin'])) {
+			$diffUrl = !empty($template['Plugin']) ? $diffPluginUrl : $diffContainerUrl;
 			$supportContext[] = [
 				"icon"   => "ca_fa-diff",
-				"action" => "caShowTemplateDiff({$diffPath},{$diffName},'internal')",
+				"action" => "caShowTemplateDiff({$diffUrl},{$diffName},'internal')",
 				"text"   => tr("CA"),
 				"class"  => "ca_devMode",
 			];

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -3275,8 +3275,18 @@ input[type="button"] {
 	4) Third Party Components
 	========================================================================== */
 
-	/* Awesomplete Autocomplete Component */
-	.awesomplete {
+	/* Awesomplete Autocomplete Component.
+
+	   EVERY rule in this block is gated by `body.ca_searchModalOpen
+	   #searchFilter ...` so:
+	     - it only matches when CA's own search modal is open
+	     - it only matches OUR awesomplete instance (the one inside
+	       #searchFilter), never some other plugin's awesomplete
+	       elsewhere on the Unraid page
+	   Previously these were plain `.awesomplete ...` selectors and were
+	   trashing other plugins' awesomplete dropdowns by bleeding our
+	   colors / list styling / pointer-events rules onto them. */
+	body.ca_searchModalOpen #searchFilter .awesomplete {
 		/* Layout */
 		display: inline-block;
 		position: relative;
@@ -3284,11 +3294,11 @@ input[type="button"] {
 		color: inherit;
 	}
 
-	.awesomplete > input {
+	body.ca_searchModalOpen #searchFilter .awesomplete > input {
 		display: block;
 	}
 
-	.awesomplete > ul {
+	body.ca_searchModalOpen #searchFilter .awesomplete > ul {
 		/* Layout */
 		position: absolute;
 		left: 0;
@@ -3307,56 +3317,61 @@ input[type="button"] {
 		font-size: 1.5rem;
 	}
 
-	.awesomplete > ul:empty {
+	body.ca_searchModalOpen #searchFilter .awesomplete > ul:empty {
 		display: none;
 	}
 
-	.awesomplete [hidden] {
+	body.ca_searchModalOpen #searchFilter .awesomplete [hidden] {
 		display: none;
 	}
 
 	/* While the Awesomplete dropdown is open, prevent the menu from scrolling (wheel events can
-	otherwise scroll the menu under the dropdown, causing scrollbars/indicators to appear). */
-	body:has(.awesomplete > ul:not([hidden]):not(:empty)) .menuItems {
+	otherwise scroll the menu under the dropdown, causing scrollbars/indicators to appear). The
+	body:has() walks the subtree so the awesomplete inside #searchFilter still triggers it. */
+	body.ca_searchModalOpen:has(#searchFilter .awesomplete > ul:not([hidden]):not(:empty)) .menuItems {
 		overflow: hidden !important;
 	}
 
-	body:has(.awesomplete > ul:not([hidden]):not(:empty)) .menuItems:hover::-webkit-scrollbar:vertical,
-	body:has(.awesomplete > ul:not([hidden]):not(:empty)) .menuItems:hover::-webkit-scrollbar:horizontal {
+	body.ca_searchModalOpen:has(#searchFilter .awesomplete > ul:not([hidden]):not(:empty)) .menuItems:hover::-webkit-scrollbar:vertical,
+	body.ca_searchModalOpen:has(#searchFilter .awesomplete > ul:not([hidden]):not(:empty)) .menuItems:hover::-webkit-scrollbar:horizontal {
 		width: 0px !important;
 		height: 0px !important;
 	}
 
-	body:has(.awesomplete > ul:not([hidden]):not(:empty)) .ca_scroll_menuitems {
+	body.ca_searchModalOpen:has(#searchFilter .awesomplete > ul:not([hidden]):not(:empty)) .ca_scroll_menuitems {
 		display: none !important;
 	}
 
-	/* When Awesomplete is open, block clicks except the dropdown, toolbar SEARCH, and modal ? / X. */
-	body.ca_awesomplete_open * {
+	/* When Awesomplete is open, block clicks except the dropdown, toolbar SEARCH, and modal ? / X.
+	   `ca_awesomplete_open` is CA's own state class (only set by our code), so this block isn't
+	   bleeding into other plugins' awesomplete — but pair the search-modal gate alongside it for
+	   defense-in-depth: if `ca_awesomplete_open` ever lingers without `ca_searchModalOpen` due to
+	   a future bug, we don't silently disable pointer events on the entire page. */
+	body.ca_searchModalOpen.ca_awesomplete_open * {
 		pointer-events: none;
 	}
-	body.ca_awesomplete_open .awesomplete,
-	body.ca_awesomplete_open .awesomplete *,
-	body.ca_awesomplete_open .searchButton,
-	body.ca_awesomplete_open .caSearchModalIconControls,
-	body.ca_awesomplete_open .caSearchModalIconControls * {
+	body.ca_searchModalOpen.ca_awesomplete_open #searchFilter .awesomplete,
+	body.ca_searchModalOpen.ca_awesomplete_open #searchFilter .awesomplete *,
+	body.ca_searchModalOpen.ca_awesomplete_open .searchButton,
+	body.ca_searchModalOpen.ca_awesomplete_open .caSearchModalIconControls,
+	body.ca_searchModalOpen.ca_awesomplete_open .caSearchModalIconControls * {
 		pointer-events: auto;
 	}
 
-	.awesomplete .visually-hidden {
+	body.ca_searchModalOpen #searchFilter .awesomplete .visually-hidden {
 		position: absolute;
 		clip: rect(0, 0, 0, 0);
 	}
 
 	/* Awesomplete Animations */
 	@supports (transform: scale(0)) {
-		.awesomplete > ul {
+		body.ca_searchModalOpen #searchFilter .awesomplete > ul {
 			transition: transform 0.3s cubic-bezier(0.4, 0.2, 0.5, 1.4);
 			transform-origin: 1.43em -0.43em;
 		}
 
-		.awesomplete > ul[hidden],
-		.awesomplete > ul:empty {
+		body.ca_searchModalOpen #searchFilter .awesomplete > ul[hidden],
+		body.ca_searchModalOpen #searchFilter .awesomplete > ul:empty {
 			opacity: 0;
 			transform: scale(0);
 			display: block;
@@ -3365,7 +3380,7 @@ input[type="button"] {
 	}
 
 	/* Awesomplete Dropdown Pointer */
-	.awesomplete > ul:before {
+	body.ca_searchModalOpen #searchFilter .awesomplete > ul:before {
 		content: "";
 		position: absolute;
 		top: -0.43em;
@@ -3381,31 +3396,31 @@ input[type="button"] {
 	}
 
 	/* Awesomplete List Items */
-	.awesomplete > ul > li {
+	body.ca_searchModalOpen #searchFilter .awesomplete > ul > li {
 		position: relative;
 		padding: 0.2em 0.5em;
 		cursor: pointer;
 	}
 
-	.awesomplete > ul > li:hover {
+	body.ca_searchModalOpen #searchFilter .awesomplete > ul > li:hover {
 		background: var(--ca-hsl-light-blue);
 		color: var(--ca-named-black);
 	}
 
-	.awesomplete > ul > li[aria-selected="true"] {
+	body.ca_searchModalOpen #searchFilter .awesomplete > ul > li[aria-selected="true"] {
 		background: var(--ca-hsl-dark-blue);
 		color: var(--ca-named-white);
 	}
 
-	.awesomplete mark {
+	body.ca_searchModalOpen #searchFilter .awesomplete mark {
 		background: var(--ca-hsl-yellow);
 	}
 
-	.awesomplete li:hover mark {
+	body.ca_searchModalOpen #searchFilter .awesomplete li:hover mark {
 		background: var(--ca-hsl-light-yellow);
 	}
 
-	.awesomplete li[aria-selected="true"] mark {
+	body.ca_searchModalOpen #searchFilter .awesomplete li[aria-selected="true"] mark {
 		background: var(--ca-hsl-green);
 		color: inherit;
 	}


### PR DESCRIPTION
## Summary

Move the initial application-feed download to a slimmed-down variant (no per-template `Config` blocks) so the first paint is faster, then lazy-hydrate the full feed in the background once the slim render is on screen. The full feed is only needed for install-time port-conflict detection, so by the time a user opens an app's sidebar and clicks Install, the full cache is already warm.

Also lands a chunk of memory and UX cleanup that fell out of the refactor.

## What changed

**Feed download (`include/exec.php`, `include/paths.php`)**
- `DownloadApplicationFeed()` now pulls `applicationFeed-small.json` from `ca.unraid.net` first; on failure, falls back to the slim copy mirrored on GitHub (`Squidly271/AppFeed`). No more "if slim fails, try full" — if the slim download fails twice we just error out.
- Per-template processing loop extracted into `processApplicationFeed()` so the slim path and any future variant share one code path.
- New `hydrateFullFeedWork()` does the full-feed download + cache write; it's exposed as a dispatcher action (`hydrateFullFeed`) the foreground JS kicks off after the slim render, and `createXML` also calls it synchronously as a safety net if a user clicks Install before background hydrate finishes.
- New `application-feed-small` / `application-feed-smallBackup` URLs in `CA_PATHS`. `diffFeedCache` renamed to `rawAppFeed` (4 refs across `exec.php`, `paths.php`, `diff.php`) — the name was a leftover from when only the diff button consumed it; it's now the canonical raw-feed snapshot.

**Cache discipline (`include/helpers.php`)**
- `writeGlobals()` only touches the slim cache now. The full cache is written exclusively by the hydrate path. This fixes a regression where reloading Apps without a feed update was rewriting `templates.json` (slim) with the full-cache contents because `getFullGlobals()` had populated `$GLOBALS['templates']` with the fat version.
- `force_update` switched from `getFullGlobals()` → `getGlobals()` so the no-download branch doesn't bloat the slim cache.
- Extracted `signalFeedReady()` — `touch(haveTemplates)` + `ca_publish` of the originating tabId.

**Cross-tab signaling (`Apps.page`)**
- Subscriber filters by tabId: if the published message equals our own tabId, skip the reload banner. Replaces the brittle `caGettingTemplatesSubIgnoreFirst` first-message-is-mine flag. Foreign tabs still get the banner as before.
- Force-update callback now posts `{action:'hydrateFullFeed'}` to kick background hydrate.

**Diff button memory (`include/diff.php`, `javascript/diff.js`, `skins/Narrow/skin_helpers.php`)**
- `getTemplateDiff()` was eating 3× the templates array in memory (the populated `$GLOBALS['templates']`, a copy `$templates = $GLOBALS['templates']`, and a `readJsonFile()` of the even-larger raw feed) — enough to OOM the 256M PHP limit on large feeds.
- New flow: button passes the template's URL straight from the DOM → server `unset($GLOBALS['templates'])` immediately → `readJsonFile(rawAppFeed)` + `searchArray` by TemplateURL/PluginURL → extract the one matching entry → `unset($rawFeed)` → `getGlobals()` again. Peak memory bounded to one large array at a time.
- Internal (CA-moderator) diff path: same shape, against the live full cache instead of raw.
- Diff button is hidden in the sidebar when the template has no URL (nothing to diff against).

**CSS isolation (`skins/Narrow/styles/community.applications.css`)**
- All `.awesomplete` selectors scoped to `body.ca_searchModalOpen #searchFilter .awesomplete` so CA's search-modal autocomplete styling no longer leaks onto other Unraid plugins' awesomplete dropdowns on the same page.

## Test plan

- [ ] Cold load `/Apps` — slim feed paints quickly, full hydrate happens in background, no banner on the originating tab
- [ ] Open a second tab during slim render — second tab gets the "feed updated" banner when slim completes
- [ ] Click Install on an app immediately after the slim paint (before background hydrate finishes) — `createXML` safety net runs hydrate synchronously and port-conflict detection still works
- [ ] Reload `/Apps` with feed already cached — `templates.json` stays slim, no full-cache contents written to it
- [ ] With primary feed URL DNS-blocked — slim GitHub backup kicks in; no full-feed second try
- [ ] Dev-mode Diff button on a container — diff renders, PHP memory stays well under 256M on a large feed
- [ ] Awesomplete dropdown on a non-CA page elsewhere in Unraid GUI — unaffected by CA's CSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster initial app-feed load with slim first render and background full-feed hydration.
  * Reduced memory use and avoided unnecessary cache rewrites on reload.

* **Bug Fixes**
  * Feed-refresh banner suppressed for the initiating tab.
  * Empty/duplicate websocket messages ignored to prevent spurious reloads.
  * More reliable fallback when primary feed is unreachable.

* **Developer Tools**
  * Diff workflow now uses template URLs to avoid large in-memory payloads.

* **Style**
  * Search autocomplete styling scoped to the app to prevent cross-plugin leakage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->