### PR TITLE
chore: drop localONLY toggle + bump search-popup suggestion buttons

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: Search suggestion buttons in the search popup are about 50% larger — easier to read and click, especially on a phone-sized viewport
 - Changed: Initial application-feed download now grabs a slimmed-down feed (no Config blocks) for a faster first paint — the full feed loads in the background so install-time port-conflict detection is ready by the time the user clicks Install
 - Changed: If the primary application feed is unreachable, CA now falls back to a slim copy hosted on GitHub instead of pulling the full feed as a second try
 - Fixed: Reloading Apps without a feed update no longer rewrites the small templates cache with the full-cache contents

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -508,9 +508,6 @@ $(function(){
 	<? endif; ?>
 	if ( "<?=$ServerDateCorrect?>" == "false" ) addBannerWarning("<?tr("Server Date and Time Incorrect.  Issues will result with Community Applications.  Fix this in Settings - Date And Time");?>",true,true);
 	if ( "<?=$RequirementsBanner?>" == "true" ) addBannerWarning("<?tr("Memory Requirements not met.  Problems may result");?>");
-	<?if ( CA_PATHS['localONLY'] == true ):?>
-		addBannerWarning("*** LOCAL FEED RUNNING - DO NOT RELEASE ***",true,true);
-	<?endif;?>
 	context.init({preventDoubleContext:false,left:true,above:'auto'});
 
 	var downloadProgress = new NchanSubscriber('/sub/ca_downloadProgress',{subscriber:'websocket'});

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -287,21 +287,6 @@ function DownloadApplicationFeed() {
 	@unlink(CA_PATHS['downloadLocks']);
 	@mkdir(CA_PATHS['templates-community'],0777,true);
 
-	if ( CA_PATHS['localONLY'] ) {
-		$ApplicationFeed = json_decode(file_get_contents(CA_PATHS['application-feed-local']),true);
-		if ( ! is_array($ApplicationFeed['applist'] ?? null) || empty($ApplicationFeed['applist']) ) {
-			return false;
-		}
-		/* Local feed IS the full applicationFeed.json (no slim/full split in
-		   localONLY mode), so stash it as the raw-feed snapshot for the
-		   dev-mode Diff button. Mirrors the @copy in hydrateFullFeedWork's
-		   remote path — without it, dev-mode diff is unreachable in localONLY. */
-		if ( ($GLOBALS['caSettings']['dev'] ?? null) === "yes" ) {
-			@copy(CA_PATHS['application-feed-local'], CA_PATHS['rawAppFeed']);
-		}
-		return processApplicationFeed($ApplicationFeed, "Local") ? 'slim' : false;
-	}
-
 	$downloadURL = randomFile();
 	/* ca_gettingTemplates publish (the "other tab updated the feed" trigger)
 	   has moved into writeGlobals via signalFeedReady() — fires when the
@@ -584,43 +569,26 @@ function hydrateFullFeedWork(): string {
 	   full cache file's mere existence means it was written by either a
 	   full-feed download or a prior hydrate — no stale state to worry about. */
 	if ( is_file(CA_PATHS['community-templates-info-full']) ) {
-		/* Backfill the dev-mode raw-feed snapshot in localONLY mode if dev
-		   mode got toggled on after the prior hydrate wrote the full cache
-		   without it. Cheap file copy — keeps the Diff button reachable
-		   without forcing a redownload. */
-		if ( CA_PATHS['localONLY'] && $devMode && ! is_file(CA_PATHS['rawAppFeed']) ) {
-			@copy(CA_PATHS['application-feed-local'], CA_PATHS['rawAppFeed']);
-		}
 		return 'already_fresh';
 	}
 
-	if ( CA_PATHS['localONLY'] ) {
-		$ApplicationFeed = json_decode(file_get_contents(CA_PATHS['application-feed-local']), true);
-		$label = "Local (hydrate)";
-		/* Stash the local feed as the raw-feed snapshot for the dev-mode
-		   Diff button — same intent as the remote-path @copy below. */
-		if ( $devMode && is_array($ApplicationFeed['applist'] ?? null) && ! empty($ApplicationFeed['applist']) ) {
-			@copy(CA_PATHS['application-feed-local'], CA_PATHS['rawAppFeed']);
-		}
-	} else {
-		$downloadURL = randomFile();
-		$ApplicationFeed = download_json(CA_PATHS['application-feed'], $downloadURL, 600, false);
-		$label = "Primary Server (hydrate)";
-		if ( (! is_array($ApplicationFeed['applist'] ?? null)) || empty($ApplicationFeed['applist']) ) {
-			$ApplicationFeed = download_json(CA_PATHS['pluginProxy'].CA_PATHS['application-feedBackup'], $downloadURL, 600, false);
-			$label = "Backup Server (hydrate)";
-		}
-		/* Dev mode: stash the raw applicationFeed.json snapshot before
-		   deleting the per-request tempfile so the Diff/Plugin/Template
-		   modals don't have to re-download it. The slim-feed download in
-		   DownloadApplicationFeed() never produced this cache (it grabs
-		   the slimmed-down file), so the full-feed hydrate is the
-		   responsible writer in the slim-first path. */
-		if ( is_array($ApplicationFeed['applist'] ?? null) && ! empty($ApplicationFeed['applist']) && $devMode ) {
-			@copy($downloadURL, CA_PATHS['rawAppFeed']);
-		}
-		@unlink($downloadURL);
+	$downloadURL = randomFile();
+	$ApplicationFeed = download_json(CA_PATHS['application-feed'], $downloadURL, 600, false);
+	$label = "Primary Server (hydrate)";
+	if ( (! is_array($ApplicationFeed['applist'] ?? null)) || empty($ApplicationFeed['applist']) ) {
+		$ApplicationFeed = download_json(CA_PATHS['pluginProxy'].CA_PATHS['application-feedBackup'], $downloadURL, 600, false);
+		$label = "Backup Server (hydrate)";
 	}
+	/* Dev mode: stash the raw applicationFeed.json snapshot before
+	   deleting the per-request tempfile so the Diff/Plugin/Template
+	   modals don't have to re-download it. The slim-feed download in
+	   DownloadApplicationFeed() never produced this cache (it grabs
+	   the slimmed-down file), so the full-feed hydrate is the
+	   responsible writer in the slim-first path. */
+	if ( is_array($ApplicationFeed['applist'] ?? null) && ! empty($ApplicationFeed['applist']) && $devMode ) {
+		@copy($downloadURL, CA_PATHS['rawAppFeed']);
+	}
+	@unlink($downloadURL);
 
 	if ( ! is_array($ApplicationFeed['applist'] ?? null) || empty($ApplicationFeed['applist']) ) {
 		return 'failed';
@@ -1430,10 +1398,6 @@ function force_update() {
 	   path write the full templates (Config and all) back to the small
 	   cache, defeating the whole point of having two caches. */
 	getGlobals();
-
-	if (!empty(CA_PATHS['localONLY'])) {
-		ForceUpdateHelpers::resetTemplatesCache(true);
-	}
 
 	$lastUpdatedOld = readJsonFile(CA_PATHS['lastUpdated-old']);
 	debug("old feed timestamp: ".($lastUpdatedOld['last_updated_timestamp'] ?? ""));

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
@@ -80,7 +80,6 @@ define("CA_PATHS",[
 	'community-templates-catSearchResults'=> "$tempFiles/catSearchResults{$caTabSuffix}.json", /* per-tab */
 	'startupDisplayed'                    => "$tempFiles/startupDisplayed{$caTabSuffix}",      /* per-tab */
 	'repositoriesDisplayed'               => "$tempFiles/repositoriesDisplayed{$caTabSuffix}.json", /* per-tab */
-	'localONLY'                           => false,    /* THIS MUST NOT BE SET TO TRUE WHEN DOING A RELEASE */
 	'application-feed'                    => "https://ca.unraid.net/assets/feed/applicationFeed.json",
 	/* Slimmed-down feed: same shape as the full feed, just with each template's
 	   Config entries stripped out. Primary-only — GitHub backup serves only the
@@ -94,9 +93,8 @@ define("CA_PATHS",[
 	   pulling the full feed as a third try. */
 	'application-feed-smallBackup'        => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed-small.json",
 	'application-feed-last-updatedBackup' => "https://raw.githubusercontent.com/Squidly271/AppFeed/master/applicationFeed-lastUpdated.json",
-	'application-feed-local'              => "/tmp/GitHub/AppFeed/applicationFeed.json",
 	'appFeedDownloadError'                => "$tempFiles/downloaderror.txt",
-	'rawAppFeed'                       => "$tempFiles/applicationFeed-raw.json", /* raw applicationFeed.json snapshot — populated by hydrateFullFeedWork() (and the localONLY branch of DownloadApplicationFeed) ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
+	'rawAppFeed'                       => "$tempFiles/applicationFeed-raw.json", /* raw applicationFeed.json snapshot — populated by hydrateFullFeedWork() ONLY when dev mode is enabled, consumed by the dev-mode Diff button (caGetCachedApplicationFeed) */
 	'caAdmin'                             => "/boot/config/plugins/community.applications/admin", /* marker file: when present alongside dev mode, exposes the Internal diff button */
 	'categoryList'                        => "$tempFiles/categoryList.json",
 	'repositoryList'                      => "$tempFiles/repositoryList.json",

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -615,9 +615,9 @@ body,
 	body.ca_searchModalOpen #searchFilter .awesomplete > ul > li.caButton {
 		display: inline-block !important;
 		margin-right: 1rem !important;
-		padding: 1px 10px !important;
-		font-size: 1.2rem !important;
-		line-height: 2rem !important;
+		padding: 2px 15px !important;
+		font-size: 1.8rem !important;
+		line-height: 3rem !important;
 		color: var(--support-popup-text) !important;
 		background: linear-gradient(
 		to bottom,


### PR DESCRIPTION
## Summary

Two unrelated cleanups bundled together:

### 1. Remove the `localONLY` local-feed dev toggle (chore)

`CA_PATHS['localONLY']` was a dev-only flag that swapped the application-feed download from `ca.unraid.net` / GitHub to a local file at `/tmp/GitHub/AppFeed/applicationFeed.json`. Useful during feed development, risky in production — the constant shipped as `false`, the doc comment warned "THIS MUST NOT BE SET TO TRUE WHEN DOING A RELEASE", and a "*** LOCAL FEED RUNNING - DO NOT RELEASE ***" banner fired on `Apps.page` when it was on.

Removing the support code entirely so the toggle can't be accidentally flipped on. If we ever need local-feed testing again, we can add it temporarily on a one-off branch.

**Changes:**
- **`include/paths.php`** — drop `'localONLY' => false` + `'application-feed-local'` constants; trim the rawAppFeed doc comment.
- **`include/exec.php`** — three blocks removed:
  - `DownloadApplicationFeed()`: early-return localONLY block (~14 lines).
  - `hydrateFullFeedWork()`: localONLY backfill in the `already_fresh` fast-path + the `if (CA_PATHS['localONLY']) {...} else {...}` two-branch download collapsed to just the remote path.
  - `force_update()`: the `if (!empty(CA_PATHS['localONLY']))` `resetTemplatesCache(true)` block.
- **`Apps.page`** — drop the `*** LOCAL FEED RUNNING - DO NOT RELEASE ***` banner.

`grep` across PHP / .page / .html / .js / .cfg confirms zero remaining `localONLY` / `application-feed-local` references. No user-visible behavior change (toggle always shipped off), so no CHANGES.md entry for this part.

### 2. Bump search-popup suggestion buttons ~50% larger (feat)

`body.ca_searchModalOpen #searchFilter .awesomplete > ul > li.caButton` goes from `font-size: 1.2rem; line-height: 2rem; padding: 1px 10px` → `font-size: 1.8rem; line-height: 3rem; padding: 2px 15px`. Easier to read and click, especially on phone-sized viewports where the suggestion list is the main interaction surface. CHANGES.md bullet added.

## Notes

- PHP lint clean on all modified files.
- No `.plg` bump, no `ca.md5` touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed local-only feed mode support and related behavior from the feed handling and page flow.
  * Removed the local-feed warning banner from the interface.

* **Style**
  * Increased size, padding, and line-height of search suggestion buttons for improved readability and tapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->