### PR TITLE
feat: polling-based cross-tab feed-update detection + sidebar pending notice + UI cleanups

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -31,7 +31,6 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 - Changed: Initial application-feed download now grabs a slimmed-down feed (no Config blocks) for a faster first paint — the full feed loads in the background so install-time port-conflict detection is ready by the time the user clicks Install
 - Changed: If the primary application feed is unreachable, CA now falls back to a slim copy hosted on GitHub instead of pulling the full feed as a second try
 - Fixed: Reloading Apps without a feed update no longer rewrites the small templates cache with the full-cache contents
-- Fixed: The tab that triggered a feed refresh no longer surfaces its own "another instance updated the feed" reload banner — the publish now carries the originating tab's id and the subscriber skips messages it sent itself
 - Fixed: CA's search-modal autocomplete styling no longer leaks onto other Unraid plugins' awesomplete dropdowns elsewhere on the page
 - Changed: Developer-mode template Diff button now passes the template URL straight to the server instead of looking it up by Path — drops two huge in-memory copies of the templates array and keeps the diff under PHP's 256M memory limit on large feeds
 - Added: "Use whole display window" setting (Settings panel, default off, 7.2+ only) — reclaims the Unraid OS header strip so the app browsing area fills the full browser window

--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,10 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: Sidebar "Pin" button moved from the action button row to the support button row (right before any dev-mode buttons) — declutters the action row and groups the toggle with the other passive on/off buttons
+- Changed: Sidebar action buttons show "Unavailable until feed downloads" when opened before the background full-feed hydrate completes — buttons appear in place automatically the moment the hydrate finishes
+- Changed: When an app has an Update available, the "Install second" button is hidden in the sidebar — installing a second instance while an update is pending would have copied the old image anyway
+- Fixed: Another browser tab updating the application feed no longer requires the current tab to be lucky with timing to see the reload banner — the check now runs the next time the user does anything on the stale tab, instead of relying on a real-time push that could be missed
 - Changed: Search suggestion buttons in the search popup are about 50% larger — easier to read and click, especially on a phone-sized viewport
 - Changed: Initial application-feed download now grabs a slimmed-down feed (no Config blocks) for a faster first paint — the full feed loads in the background so install-time port-conflict detection is ready by the time the user clicks Install
 - Changed: If the primary application feed is unreachable, CA now falls back to a slim copy hosted on GitHub instead of pulling the full feed as a second try

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -531,17 +531,17 @@ $(function(){
 	});
 	downloadProgress.start();
 
-	/* Subscribe but defer the .start() until downloadStatistics() runs so the
-	   tab doing the initial force_update doesn't connect early and pile up
-	   spurious connect events. Messages are filtered by tab id: signalFeedReady
-	   publishes the originating tab's data.tabId so the tab that triggered the
-	   update skips its own message — only foreign tabs surface the banner. */
-	window.caGettingTemplatesSubStarted = false;
-	window.caGettingTemplatesSub = new NchanSubscriber('/sub/ca_gettingTemplates',{subscriber:'websocket'});
-	window.caGettingTemplatesSub.on('message', function(message) {
-		if ( ! message ) return;
-		// Originating tab id from the server — skip if it's us.
-		if (data && data.tabId && message === data.tabId) return;
+	/* Cross-tab feed-update reload banner — pulled from the nchan-based
+	   subscriber that used to live here. The new flow polls server-side:
+	   once this tab has rendered its first content, post() in helpers.js
+	   attaches caFeedCheck=true to every subsequent request. exec.php's
+	   pre-switch guard checks for the displayed-{tabId}.json sentinel; if
+	   another tab triggered a feed download (which wipes tempFiles), the
+	   file is gone and the server returns {feedUpdated:true}. helpers.js's
+	   post() done callback then calls this function. No nchan, no buffered-
+	   message race; the banner only fires when the user actually does
+	   something on a stale tab. */
+	function caHandleForeignFeedUpdate() {
 		/* If a plugin / docker install (or any Unraid openPlugin / openDocker
 		   dialog) is currently on screen, hold the "another session updated
 		   the feed" notice until it's done — otherwise the viewport blocker
@@ -565,7 +565,8 @@ $(function(){
 			return;
 		}
 		fireReloadNotice();
-	});
+	}
+	window.caHandleForeignFeedUpdate = caHandleForeignFeedUpdate;
 
 	caInitializeSortMenu();
 	caInitializeClickHandlers();
@@ -634,6 +635,19 @@ $(function(){
 			&& caSavedState
 			&& !caSavedState.wasHome
 		);
+		/* Register this tab with the server before any other request. The
+		   server creates a marker file at CA_PATHS['registeredTabs']/{tabId}
+		   that gets wiped by DownloadApplicationFeed when another tab
+		   triggers a fresh feed pull. Arming caFeedTrackingArmed only
+		   after the registration response means subsequent posts can
+		   safely carry caFeedCheck=true without false-positiving on the
+		   pre-switch guard before the marker exists. Both restore and
+		   non-restore bootstrap branches below fire in parallel — they
+		   don't need the flag armed yet (their initial calls happen
+		   unguarded since flag is still false at that point). */
+		postNoSpin({action:'registerTab'}, function() {
+			window.caFeedTrackingArmed = true;
+		});
 		if ( caCanRestore ) {
 			getCategories();
 			restoreState(caSavedState);
@@ -795,8 +809,31 @@ function updateContent(button,skipAppfeed=true) {
 		   port-conflict detection and createXML have Config available by
 		   the time the user clicks Install. Server short-circuits with
 		   `already_fresh` when the full cache is already on disk, so this
-		   is safe to call unconditionally. */
-		postNoSpin({action:'hydrateFullFeed'});
+		   is safe to call unconditionally.
+
+		   On completion, if a sidebar happens to be open and showing the
+		   "Unavailable until feed downloads" notice (the slim-only render
+		   from skin.php's full-cache guard), surgically swap just the
+		   .popupStickyActions block with the freshly-rendered version
+		   from the server — no full sidebar reload, no spinner flicker,
+		   just the buttons appearing in place. */
+		postNoSpin({action:'hydrateFullFeed'}, function(hydrateResult) {
+			if (hydrateResult && hydrateResult.status === 'failed') return;
+			if (!data.sidebarapppath) return;
+			if (!$('.popupCloseAreaButtons .caFeedPending').length) return;
+			postNoSpin({action:'getPopupDescription', appName: data.sidebarappname, appPath: data.sidebarapppath}, function(popResult) {
+				if (!popResult || !popResult.description) return;
+				/* Sidebar might have closed or navigated to a different app
+				   while the popup re-fetch was in flight — re-check before
+				   touching the DOM. */
+				if (!$('.popupCloseAreaButtons .caFeedPending').length) return;
+				var $tmp = $('<div>').html(popResult.description);
+				var $newActions = $tmp.find('.popupStickyActions').first();
+				if ($newActions.length) {
+					$('.popupCloseAreaButtons .popupStickyActions').replaceWith($newActions);
+				}
+			});
+		});
 		getCategories(); /* now also re-applies count-based submenu gating */
 		if ( $.cookie("ca_plugininstallpending" || ! button ) ) {
 			var plugins = $.cookie("ca_plugininstallpending");
@@ -1130,15 +1167,9 @@ function getContent(init,category,description,newApp,startupDisplay) {
 }
 
 /**
- * Trigger background statistics/template fetch: starts the optional nchan feed when configured, then `postNoSpin` `downloadStatistics`.
+ * Trigger background statistics/template fetch.
  */
 function downloadStatistics() {
-	try {
-		if (window.caGettingTemplatesSub && !window.caGettingTemplatesSubStarted) {
-			window.caGettingTemplatesSub.start();
-			window.caGettingTemplatesSubStarted = true;
-		}
-	} catch(e) {}
 	postNoSpin({action:'downloadStatistics'});
 }
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -638,15 +638,23 @@ $(function(){
 		/* Register this tab with the server before any other request. The
 		   server creates a marker file at CA_PATHS['registeredTabs']/{tabId}
 		   that gets wiped by DownloadApplicationFeed when another tab
-		   triggers a fresh feed pull. Arming caFeedTrackingArmed only
-		   after the registration response means subsequent posts can
-		   safely carry caFeedCheck=true without false-positiving on the
-		   pre-switch guard before the marker exists. Both restore and
-		   non-restore bootstrap branches below fire in parallel — they
-		   don't need the flag armed yet (their initial calls happen
-		   unguarded since flag is still false at that point). */
-		postNoSpin({action:'registerTab'}, function() {
-			window.caFeedTrackingArmed = true;
+		   triggers a fresh feed pull.
+
+		   Arming caFeedTrackingArmed is gated on TWO events both completing:
+		     1. registerTab acked — the marker exists server-side
+		     2. bootstrap settled — downloadStatistics returned, which both
+		        the restore and non-restore boot paths fire as their last
+		        sequential step
+		   Without (2), in-flight bootstrap requests (force_update_skip,
+		   hydrateFullFeed, getCategories) would start carrying caFeedCheck
+		   mid-load — a concurrent feed refresh in another tab could then
+		   pop the "another browser updated" banner during page load
+		   instead of on the next user action. */
+		postNoSpin({action:'registerTab'}, function(result) {
+			if (result && result.status === 'ok') {
+				window.caRegisterTabAcked = true;
+				caMaybeArmFeedCheck();
+			}
 		});
 		if ( caCanRestore ) {
 			getCategories();
@@ -821,12 +829,22 @@ function updateContent(button,skipAppfeed=true) {
 			if (hydrateResult && hydrateResult.status === 'failed') return;
 			if (!data.sidebarapppath) return;
 			if (!$('.popupCloseAreaButtons .caFeedPending').length) return;
-			postNoSpin({action:'getPopupDescription', appName: data.sidebarappname, appPath: data.sidebarapppath}, function(popResult) {
+			/* Snapshot the app identity we're about to fetch, so the
+			   callback can verify the same app is still in the sidebar
+			   when the response arrives. Without this, a fast user opening
+			   a different (also pending) sidebar between request and
+			   response would have the new sidebar's action row clobbered
+			   with the PREVIOUS app's buttons. */
+			var requestedAppName = data.sidebarappname;
+			var requestedAppPath = data.sidebarapppath;
+			postNoSpin({action:'getPopupDescription', appName: requestedAppName, appPath: requestedAppPath}, function(popResult) {
 				if (!popResult || !popResult.description) return;
 				/* Sidebar might have closed or navigated to a different app
-				   while the popup re-fetch was in flight — re-check before
-				   touching the DOM. */
+				   while the popup re-fetch was in flight — re-check both
+				   the pending notice AND that the open sidebar is still
+				   the same app we requested before touching the DOM. */
 				if (!$('.popupCloseAreaButtons .caFeedPending').length) return;
+				if (data.sidebarappname !== requestedAppName || data.sidebarapppath !== requestedAppPath) return;
 				var $tmp = $('<div>').html(popResult.description);
 				var $newActions = $tmp.find('.popupStickyActions').first();
 				if ($newActions.length) {
@@ -1167,10 +1185,26 @@ function getContent(init,category,description,newApp,startupDisplay) {
 }
 
 /**
- * Trigger background statistics/template fetch.
+ * Trigger background statistics/template fetch. Also marks bootstrap as
+ * settled — see caMaybeArmFeedCheck — since both boot paths (restore and
+ * non-restore) fire this as their last sequential step.
  */
 function downloadStatistics() {
-	postNoSpin({action:'downloadStatistics'});
+	postNoSpin({action:'downloadStatistics'}, function() {
+		window.caBootstrapSettled = true;
+		caMaybeArmFeedCheck();
+	});
+}
+
+/**
+ * Arms `window.caFeedTrackingArmed` once both registerTab has acked AND
+ * bootstrap has settled. Idempotent. See the registerTab block in the
+ * IIFE near the top of this file for the rationale.
+ */
+function caMaybeArmFeedCheck() {
+	if (window.caRegisterTabAcked && window.caBootstrapSettled) {
+		window.caFeedTrackingArmed = true;
+	}
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -92,7 +92,34 @@ if ( ! $sortOrder ) {
 ##                                        ##
 ############################################
 $GLOBALS['action'] = $_POST['action'] ?? "Unknown";
+
+/* Cross-tab feed-update detection. JS sets caFeedCheck=true on every
+   request from a tab that has previously called `registerTab` (which
+   creates a per-tab marker file at CA_PATHS['registeredTabs']/{tabId}).
+   If the marker is now missing, another tab has triggered a feed
+   download (which wipes the entire tempFiles directory, including the
+   registered-tabs subfolder) and this tab is operating on stale state —
+   short-circuit the action and tell JS to throw up the reload banner.
+   Cheap is_file check on every request, no nchan, no buffered-message
+   race. The tab that initiated the download re-registers itself inside
+   DownloadApplicationFeed before returning, so the driving tab stays
+   in sync. */
+if ( ! empty($_POST['caFeedCheck']) ) {
+	$_caTabIdForCheck = (string)($_POST['tabId'] ?? '');
+	if ($_caTabIdForCheck === '' || ! file_exists(CA_PATHS['registeredTabs'] . '/' . basename($_caTabIdForCheck))) {
+		postReturn(['feedUpdated' => true]);
+		return;
+	}
+}
+
 switch ($_POST['action']) {
+	case 'registerTab':
+		/* Bootstrap-time tab registration. JS calls this once after the
+		   tab finishes its initial load and before arming the feedCheck
+		   flag. Creates the marker file the pre-switch guard checks. */
+		ensureTabRegistered();
+		postReturn(['status' => 'ok']);
+		break;
 	case 'get_content':
 		caRequireSkin();
 		get_content();
@@ -315,7 +342,15 @@ function DownloadApplicationFeed() {
 	}
 	@unlink($downloadURL);
 
-	return processApplicationFeed($smallFeed, $currentFeed) ? 'slim' : false;
+	$result = processApplicationFeed($smallFeed, $currentFeed) ? 'slim' : false;
+	/* tempFiles got wiped at the top of this function, which took the
+	   registeredID/* markers with it. The tab that drove this request
+	   is now in sync with the freshly-pulled feed — register it again
+	   so the pre-switch guard doesn't false-positive on this tab's next
+	   request. Other tabs stay unregistered intentionally, so they get
+	   the "another browser updated" banner on their next action. */
+	ensureTabRegistered();
+	return $result;
 }
 
 /**
@@ -1408,6 +1443,8 @@ function force_update() {
 		ForceUpdateHelpers::resetTemplatesCache();
 	}
 
+	/* Track whether THIS invocation actually pulled a fresh feed. */
+	$freshlyDownloaded = false;
 	if (!ForceUpdateHelpers::templatesAvailable()) {
 		if (!DownloadApplicationFeed()) {
 			@unlink(CA_PATHS['gettingTemplates']);
@@ -1415,18 +1452,27 @@ function force_update() {
 			postReturn(ForceUpdateHelpers::buildDownloadFailureResponse());
 			return;
 		}
+		$freshlyDownloaded = true;
 	}
 
-	//getConvertedTemplates();
-	moderateTemplates();
 	@unlink(CA_PATHS['gettingTemplates']);
 	$script = ForceUpdateHelpers::buildUpdateScript();
 
-	/* writeGlobals writes the slim cache (and fires the feed-ready signal).
-	   The full cache is filled in by hydrateFullFeedWork — there is no
-	   full-feed fallback in DownloadApplicationFeed anymore, so nothing
-	   here writes community-templates-info-full directly. */
-	writeGlobals($GLOBALS['templates']);
+	/* Only moderate + write back when we actually downloaded a fresh feed.
+	   On a no-download cycle the cache already on disk is the output of
+	   the last download's moderation pass — re-running moderateTemplates +
+	   writeGlobals would write identical bytes back, and only fires the
+	   cross-tab "feed updated" banner unnecessarily. The one input that
+	   could legitimately change moderation results between cycles without
+	   a download is the Unraid version (Compatible / Deprecated / Featured
+	   flags depend on it), and an OS-version change requires a reboot —
+	   which wipes /tmp, including the templates cache, so the next
+	   force_update reaches DownloadApplicationFeed and rebuilds anyway.
+	   The full cache is filled in by hydrateFullFeedWork separately. */
+	if ($freshlyDownloaded) {
+		moderateTemplates();
+		writeGlobals($GLOBALS['templates']);
+	}
 	postReturn(['status' => "ok", 'script' => $script]);
 }
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -116,9 +116,12 @@ switch ($_POST['action']) {
 	case 'registerTab':
 		/* Bootstrap-time tab registration. JS calls this once after the
 		   tab finishes its initial load and before arming the feedCheck
-		   flag. Creates the marker file the pre-switch guard checks. */
-		ensureTabRegistered();
-		postReturn(['status' => 'ok']);
+		   flag. Creates the marker file the pre-switch guard checks.
+		   Reports back whether the marker is actually on disk so the
+		   client only arms its caFeedCheck flag against a real
+		   registration — ensureTabRegistered rejects malformed tabIds
+		   and mkdir/touch failures otherwise. */
+		postReturn(['status' => ensureTabRegistered() ? 'ok' : 'failed']);
 		break;
 	case 'get_content':
 		caRequireSkin();
@@ -342,15 +345,7 @@ function DownloadApplicationFeed() {
 	}
 	@unlink($downloadURL);
 
-	$result = processApplicationFeed($smallFeed, $currentFeed) ? 'slim' : false;
-	/* tempFiles got wiped at the top of this function, which took the
-	   registeredID/* markers with it. The tab that drove this request
-	   is now in sync with the freshly-pulled feed — register it again
-	   so the pre-switch guard doesn't false-positive on this tab's next
-	   request. Other tabs stay unregistered intentionally, so they get
-	   the "another browser updated" banner on their next action. */
-	ensureTabRegistered();
-	return $result;
+	return processApplicationFeed($smallFeed, $currentFeed) ? 'slim' : false;
 }
 
 /**
@@ -1394,6 +1389,12 @@ function get_content() {
 function force_update_skip() {
 	clearstatcache();
 	if ( ! is_file(CA_PATHS['gettingTemplates']) && is_file(CA_PATHS['community-templates-info']) ) {
+		/* Tab is exiting with the slim cache it walked in expecting. If
+		   another tab's DownloadApplicationFeed wiped the registry while
+		   this request was in flight (or between the tab's registerTab
+		   and this call), the marker is gone — re-register here so a
+		   subsequent caFeedCheck doesn't false-positive as stale. */
+		ensureTabRegistered();
 		postReturn(['status' => "ok"]);
 		return;
 	}
@@ -1420,7 +1421,12 @@ function force_update() {
 			sleep(1);
 			clearstatcache();
 		}
-		// Another process should have refreshed templates; return.
+		/* The other tab's DownloadApplicationFeed wiped tempFiles
+		   (including this tab's marker) during the wait. The wait-
+		   then-ok path is now in sync with that fresh feed, so
+		   re-register here — otherwise a subsequent caFeedCheck on
+		   this tab would falsely surface the stale-feed banner. */
+		ensureTabRegistered();
 		postReturn(['status' => "ok"]);
 		return;
 	}
@@ -1473,6 +1479,15 @@ function force_update() {
 		moderateTemplates();
 		writeGlobals($GLOBALS['templates']);
 	}
+	/* Re-register the calling tab. If this invocation triggered
+	   DownloadApplicationFeed, the wipe took the marker with it and we
+	   need to restore it. If this was a no-download cycle, the marker
+	   either still exists from registerTab (re-touch is a no-op) or
+	   was wiped by ANOTHER tab's concurrent download since registerTab
+	   — in which case this tab is now in sync with that fresh feed
+	   (templates were just re-read from the post-download cache) and
+	   should be re-registered. Either way, idempotent. */
+	ensureTabRegistered();
 	postReturn(['status' => "ok", 'script' => $script]);
 }
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -141,26 +141,40 @@ function signalFeedReady() {
  * Create/refresh the per-tab registration marker for the calling tab.
  *
  * Idempotent. Reads tabId from $_POST (the JS `post()` helper stamps it
- * on every request). No-op when tabId is missing or empty.
+ * on every request). Validates against the same shape paths.php uses for
+ * per-tab cache file suffixes (`^[A-Za-z0-9_-]{8,64}$`) — anything outside
+ * that range (empty, ".", "..", overlong, contains `/`) is rejected.
+ *
+ * Returns true when the marker is provably on disk after the call, false
+ * if any step failed (validation, mkdir, touch). Callers that need to
+ * acknowledge a successful registration to the client (the `registerTab`
+ * action handler) inspect this return so the client doesn't arm
+ * caFeedTrackingArmed against a marker that doesn't actually exist.
  *
  * Called from:
  *  - the `registerTab` action handler (initial registration on tab boot)
- *  - DownloadApplicationFeed (the calling tab wiped tempFiles, but it's
- *    now in sync with the feed it just pulled — re-register it so the
- *    pre-switch guard doesn't false-positive on this tab's next request)
+ *  - the successful exit of force_update() (the calling tab's marker was
+ *    wiped along with tempFiles by DownloadApplicationFeed; the re-
+ *    register confirms this tab is in sync with the freshly-pulled feed —
+ *    other tabs stay unregistered so their next caFeedCheck surfaces
+ *    the reload banner)
  *
- * basename() on the tabId is defence-in-depth against path traversal —
- * tabIds are crypto.randomUUID() in normal flow, but the marker filename
- * comes straight from user-controlled POST so it gets sanitized.
+ * @return bool
  */
-function ensureTabRegistered() {
+function ensureTabRegistered(): bool {
 	$tabId = (string)($_POST['tabId'] ?? '');
-	if ($tabId === '') return;
-	$dir = CA_PATHS['registeredTabs'];
-	if (!is_dir($dir)) {
-		@mkdir($dir, 0777, true);
+	if (!preg_match('/^[A-Za-z0-9_-]{8,64}$/', $tabId)) {
+		return false;
 	}
-	@touch($dir . '/' . basename($tabId));
+	$dir = CA_PATHS['registeredTabs'];
+	if (!is_dir($dir) && !@mkdir($dir, 0777, true) && !is_dir($dir)) {
+		return false;
+	}
+	$path = $dir . '/' . $tabId;
+	if (!@touch($path)) {
+		return false;
+	}
+	return is_file($path);
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -84,12 +84,16 @@ function getSettings() {
 	}
 }
 /**
- * Persist the in-memory templates array to both the slim and full on-disk JSON caches.
+ * Persist the in-memory templates array to the slim on-disk JSON cache.
  *
- * Strips bulky container-config keys for the slim cache used by general
- * browsing, but keeps everything in the full file for install/createXML flows.
- * When the input is empty, both files are unlinked and $GLOBALS['templates']
- * is cleared.
+ * Called only from force_update after a fresh DownloadApplicationFeed —
+ * no-download cycles intentionally skip the moderate+write step (the
+ * cache already reflects the last download's moderation output, and the
+ * only thing that could legitimately invalidate it without a fresh
+ * feed is an Unraid OS version change which reboots and wipes /tmp).
+ *
+ * Empty-input branch left in as a safety net for explicit cache-clear
+ * callers; not currently exercised by the live code paths.
  *
  * @param  array<int,array<string,mixed>>  $templates
  * @return void
@@ -107,34 +111,56 @@ function writeGlobals($templates) {
 	   via writeJsonFile() so we don't reiterate the array here. */
 	writeJsonFile(CA_PATHS['community-templates-info'], $templates);
 	$GLOBALS['templates'] = $templates;
-	/* Feed-ready signal fires here — the slim cache is what the UI reads
-	   for card rendering, so the moment it's on disk other open CA tabs can
-	   safely reload. The background full-feed hydrate only writes the full
-	   cache (via writeJsonFile directly, bypassing writeGlobals), so it
-	   doesn't re-fire the signal — install-time data hydrates silently. */
+	/* Feed-ready signal: the slim cache just landed on disk, other CA
+	   tabs can safely reload to pick up the new content. The background
+	   full-feed hydrate writes only the full cache (via writeJsonFile
+	   directly, bypassing writeGlobals), so it doesn't re-fire the
+	   signal — install-time data hydrates silently. */
 	signalFeedReady();
 }
 
 /**
  * Mark the templates feed as fully ready: touch the haveTemplates sentinel
- * (gates enableActionCentre's wait loop) and publish on the
- * `/sub/ca_gettingTemplates` nchan channel so other open CA tabs surface
- * the reload banner. Should fire ONLY after the full templates cache has
- * been written — slim-only state must keep this signal absent so background
- * tabs aren't told the feed is ready before install-time Config data is
- * actually on disk.
+ * (gates enableActionCentre's wait loop) so background subscribers can
+ * tell when a download has completed.
  *
- * The publish payload is the originating browser tab's id (from
- * $_POST['tabId']) so the tab that triggered this update doesn't fire its
- * own reload banner — the JS subscriber compares to its local tab id and
- * skips when they match. Falls back to "1" if no tab id is on the request
- * (e.g. when called from a sync safety-net path that wasn't POSTed by JS),
- * which makes EVERY subscriber treat it as foreign and reload.
+ * Cross-tab "another browser updated the feed" used to also publish on
+ * an nchan channel here, but that was replaced with a polling-style
+ * check in exec.php's pre-switch guard (see the `caFeedCheck` block
+ * near the top of exec.php). The displayed-{tabId}.json file's
+ * existence on disk is the canonical "this tab is still in sync"
+ * signal; another tab's DownloadApplicationFeed wipes tempFiles
+ * including that file, and the guard catches it on the stale tab's
+ * next request.
  */
 function signalFeedReady() {
 	touch(CA_PATHS['haveTemplates']);
-	$originTabId = (string)($_POST['tabId'] ?? "");
-	ca_publish("ca_gettingTemplates", $originTabId !== "" ? $originTabId : "1");
+}
+
+/**
+ * Create/refresh the per-tab registration marker for the calling tab.
+ *
+ * Idempotent. Reads tabId from $_POST (the JS `post()` helper stamps it
+ * on every request). No-op when tabId is missing or empty.
+ *
+ * Called from:
+ *  - the `registerTab` action handler (initial registration on tab boot)
+ *  - DownloadApplicationFeed (the calling tab wiped tempFiles, but it's
+ *    now in sync with the feed it just pulled — re-register it so the
+ *    pre-switch guard doesn't false-positive on this tab's next request)
+ *
+ * basename() on the tabId is defence-in-depth against path traversal —
+ * tabIds are crypto.randomUUID() in normal flow, but the marker filename
+ * comes straight from user-controlled POST so it gets sanitized.
+ */
+function ensureTabRegistered() {
+	$tabId = (string)($_POST['tabId'] ?? '');
+	if ($tabId === '') return;
+	$dir = CA_PATHS['registeredTabs'];
+	if (!is_dir($dir)) {
+		@mkdir($dir, 0777, true);
+	}
+	@touch($dir . '/' . basename($tabId));
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/paths.php
@@ -80,6 +80,18 @@ define("CA_PATHS",[
 	'community-templates-catSearchResults'=> "$tempFiles/catSearchResults{$caTabSuffix}.json", /* per-tab */
 	'startupDisplayed'                    => "$tempFiles/startupDisplayed{$caTabSuffix}",      /* per-tab */
 	'repositoriesDisplayed'               => "$tempFiles/repositoriesDisplayed{$caTabSuffix}.json", /* per-tab */
+	/* Dedicated tab-registration sentinel directory. Each registered tab
+	   gets a (touched, content-less) file at "$registeredTabs/{tabId}".
+	   DownloadApplicationFeed wipes the whole `tempFiles/` tree, taking
+	   the registry with it — so any tab still operating against the old
+	   feed has no marker on disk, and its next request triggers the
+	   "another tab updated the feed" reload banner via the pre-switch
+	   guard in exec.php. The action that initiated the download
+	   re-registers itself before returning, so the user-driving tab
+	   stays in sync. JS arms `window.caFeedTrackingArmed` only after a
+	   successful `registerTab` action so the guard isn't checked before
+	   the marker exists. */
+	'registeredTabs'                      => "$tempFiles/registeredID",
 	'application-feed'                    => "https://ca.unraid.net/assets/feed/applicationFeed.json",
 	/* Slimmed-down feed: same shape as the full feed, just with each template's
 	   Config entries stripped out. Primary-only — GitHub backup serves only the

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/helpers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/helpers.js
@@ -803,6 +803,19 @@ function post(options,callback) {
 	if (options && typeof options === "object" && !options.tabId && typeof data !== "undefined" && data.tabId) {
 		options.tabId = data.tabId;
 	}
+	/* Cross-tab feed-update detection. Once a tab has rendered its first
+	   content (Apps.page arms caFeedTrackingArmed in get_content's success
+	   callback — at which point displayed-{tabId}.json is guaranteed to
+	   exist on disk), every subsequent request carries caFeedCheck=true.
+	   exec.php's pre-switch guard re-checks the file's existence; if
+	   another tab triggered a DownloadApplicationFeed (which wipes
+	   tempFiles), the file is gone and the server short-circuits with
+	   feedUpdated=true — the done callback below shows the reload banner.
+	   No nchan, no buffered-message race; the check only fires when the
+	   user actually does something on a stale tab. */
+	if (window.caFeedTrackingArmed && !options.caFeedCheck) {
+		options.caFeedCheck = true;
+	}
 	if ( ! options.noSpinner ) {
 		if ( postCount == 0) {
 			if ( ! $(".ca_sweetalert_open").length ) {
@@ -814,6 +827,24 @@ function post(options,callback) {
 	}
 
 	$.post(execURL,options).done(function(result) {
+		/* Server's pre-switch guard short-circuited: another tab triggered
+		   a feed download while this tab was sitting around, our per-tab
+		   displayed cache is gone, and the action we were about to do
+		   would be running against stale state. Show the reload banner
+		   and stop processing this response (no script eval, no caller
+		   callback — they'd be operating on the empty {feedUpdated:true}
+		   payload anyway). */
+		if (result && result.feedUpdated) {
+			if (typeof caHandleForeignFeedUpdate === "function") {
+				caHandleForeignFeedUpdate();
+			}
+			if ( ! options.noSpinner ) {
+				postCount--;
+				if (postCount < 0) postCount = 0;
+				if (postCount === 0) myCloseSpinner();
+			}
+			return;
+		}
 		if (result.script) {
 			try {
 				eval(result.script);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -513,6 +513,23 @@ function displayPopup($template) {
 		}
 	}
 
+	/* When an Update is available, drop "Install second" from the install
+	   bucket. The combination doesn't make sense: a second instance of an
+	   app that has an update pending would install at the old image
+	   version anyway (createXML reads the same template), and offering
+	   both nudges the user toward the wrong action. Updating first is
+	   the right path; Install second can come back the next time the
+	   sidebar opens (no update pending). */
+	if (!empty($rightUpdateActionItems)) {
+		$rightInstallActionItems = array_values(array_filter(
+			$rightInstallActionItems,
+			static function ($item) {
+				$text = trim(strip_tags((string)($item['text'] ?? "")));
+				return $text !== tr("Install second") && $text !== "Install second";
+			}
+		));
+	}
+
 	ob_start();
 	?>
 	<div class='popup'>
@@ -536,10 +553,33 @@ function displayPopup($template) {
 					<?php /* Support buttons stay in the popup body and scroll
 					         with the rest of the content. Action buttons live
 					         in .popupStickyActions below this block and get
-					         relocated to the close area by JS. */ ?>
-					<?php if (!empty($supportContext)): ?>
+					         relocated to the close area by JS. The Pin button
+					         used to live in .popupStickyActions too; now it
+					         sits at the end of this row, slotted in just
+					         before the first dev-mode button (if any) so the
+					         dev-only stuff stays grouped at the far end. */ ?>
+					<?php
+					$showPin = ($LanguagePack !== "en_US" && ! $Blacklist && ! $NoPin);
+					/* Index where the pin should be inserted in the support
+					   row. Default: after all support buttons (length). If a
+					   support entry carries `ca_devMode` in its class field,
+					   the pin slots in just before it instead. */
+					$pinInsertIdx = $showPin ? count($supportContext) : -1;
+					if ($showPin) {
+						foreach ($supportContext as $_pinIdx => $_pinSc) {
+							if (strpos((string)($_pinSc['class'] ?? ''), 'ca_devMode') !== false) {
+								$pinInsertIdx = $_pinIdx;
+								break;
+							}
+						}
+					}
+					?>
+					<?php if (!empty($supportContext) || $showPin): ?>
 						<div class='popupSupportRow'>
-							<?php foreach ($supportContext as $sc): ?>
+							<?php foreach ($supportContext as $_scIdx => $sc): ?>
+								<?php if ($showPin && $_scIdx === $pinInsertIdx): ?>
+									<div class='caButton supportPopup pinPopup <?= htmlspecialchars((string)$pinnedClass, ENT_QUOTES) ?>' data-repository='<?= htmlspecialchars((string)$Repository, ENT_QUOTES) ?>' data-name='<?= htmlspecialchars((string)$SortName, ENT_QUOTES) ?>'><span><?= tr("Pin") ?></span></div>
+								<?php endif; ?>
 								<?php
 								/* Optional caller-supplied extra class (e.g. ca_devMode for
 								   dev-mode-only buttons) — appended to the static caButton +
@@ -552,6 +592,9 @@ function displayPopup($template) {
 									<div class='caButton supportPopup<?= $scExtraClass ?>'><a href='<?= htmlspecialchars($sc['link'], ENT_QUOTES) ?>' target='_blank'><span class='<?= $sc['icon'] ?>'> <?= $sc['text'] ?></span></a></div>
 								<?php endif; ?>
 							<?php endforeach; ?>
+							<?php if ($showPin && $pinInsertIdx >= count($supportContext)): ?>
+								<div class='caButton supportPopup pinPopup <?= htmlspecialchars((string)$pinnedClass, ENT_QUOTES) ?>' data-repository='<?= htmlspecialchars((string)$Repository, ENT_QUOTES) ?>' data-name='<?= htmlspecialchars((string)$SortName, ENT_QUOTES) ?>'><span><?= tr("Pin") ?></span></div>
+							<?php endif; ?>
 						</div>
 					<?php endif; ?>
 
@@ -575,6 +618,18 @@ function displayPopup($template) {
 			         (community.applications.css) relies on this DOM order to
 			         right-align the right group as one contiguous block. */ ?>
 			<div class='popupStickyActions'>
+				<?php /* While the full-feed hydrate is still in flight (background fetch
+				         kicked off after the slim-feed bootstrap finishes), the action
+				         buttons can't do anything useful — Install / Reinstall /
+				         Install-second-instance / Edit all need Config blocks that only
+				         live in the full feed. Surface a "wait for the feed" message in
+				         the action-row slot instead. Existence check on the full-cache
+				         JSON is the canonical "hydrate complete" signal. Refreshing the
+				         sidebar (re-clicking the card) after the hydrate finishes will
+				         re-render this block with the live buttons. */ ?>
+				<?php if ( ! is_file(CA_PATHS['community-templates-info-full']) ): ?>
+					<div class='caFeedPending'><?= tr("Unavailable until feed downloads") ?></div>
+				<?php else: ?>
 				<?php /* Always htmlspecialchars(..., ENT_QUOTES) the action onclick — these
 				         strings get built with interpolated template data (RequiresFile,
 				         pluginName, paths, etc.) and an unescaped emit lets a hostile
@@ -616,9 +671,8 @@ function displayPopup($template) {
 					<?php endif; ?>
 				<?php endforeach; ?>
 
-				<?php if ($LanguagePack !== "en_US" && ! $Blacklist && ! $NoPin): ?>
-					<div class='caButton pinPopup <?= htmlspecialchars((string)$pinnedClass, ENT_QUOTES) ?>' data-repository='<?= htmlspecialchars((string)$Repository, ENT_QUOTES) ?>' data-name='<?= htmlspecialchars((string)$SortName, ENT_QUOTES) ?>'><span><?= tr("Pin") ?></span></div>
-				<?php endif; ?>
+				<?php /* Pin button moved to .popupSupportRow above — see the
+				         insertion block in the support section. */ ?>
 
 				<?php /* === RIGHT BLUE GROUP — install-family ===================== */ ?>
 				<?php if (!empty($installFirstAction['action'])): ?>
@@ -654,6 +708,7 @@ function displayPopup($template) {
 				<?php if (!empty($popupUninstallAction['action'])): ?>
 					<div class='caButton actionsPopup actionsUninstall'><span onclick="<?= htmlspecialchars($popupUninstallAction['action'], ENT_QUOTES) ?>"><?= htmlspecialchars(trim(strip_tags((string)($popupUninstallAction['text'] ?? tr("Uninstall")))), ENT_QUOTES) ?></span></div>
 				<?php endif; ?>
+				<?php endif; /* full-feed-present guard */ ?>
 			</div>
 
 			<?= $ModeratorCommentBlock ?>

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -611,6 +611,16 @@ body,
 		margin-left: 0;
 	}
 
+	/* Shown in place of the action buttons when the sidebar is opened
+	   before the background full-feed hydrate finishes — Install / Update
+	   / Edit etc. need Config blocks that only live in the full feed.
+	   Plain notice text, no button styling. */
+	.popupStickyActions > .caFeedPending {
+		font-style: italic;
+		opacity: 0.75;
+		padding: 0.4rem 0.5rem;
+	}
+
 	/* Awesomplete suggestions: use caButton styling, force precedence */
 	body.ca_searchModalOpen #searchFilter .awesomplete > ul > li.caButton {
 		display: inline-block !important;
@@ -2571,7 +2581,8 @@ input[type="button"] {
 	   icon-less buttons. */
 	.popupCloseAreaButtons .popUpClose::before,
 	.popupCloseAreaButtons .caButton::before,
-	#caDiffView .caDiffClose::before {
+	#caDiffView .caDiffClose::before,
+	.popupSupportRow .pinPopup::before {
 		margin-right: 0.5rem;
 	}
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/azure.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/azure.css
@@ -29,7 +29,7 @@
 		--ca-button-blue-hover: var(--unraid-66-color);
 		/* Green-button palette (.actionsUpdate). Same hover contract as
 		   the blue/red variants — lifts to brand orange. */
-		--ca-button-green: #1d8a1d;
+		--ca-button-green: #177817;
 		--ca-button-green-hover: var(--unraid-66-color);
 		--ca-legacy-background-color: var(--background-color,#e8e8e8);
 		--ca-search-modal-background: var(--ca-legacy-background-color);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/azure.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/azure.css
@@ -29,7 +29,7 @@
 		--ca-button-blue-hover: var(--unraid-66-color);
 		/* Green-button palette (.actionsUpdate). Same hover contract as
 		   the blue/red variants — lifts to brand orange. */
-		--ca-button-green: #2ca22c;
+		--ca-button-green: #1d8a1d;
 		--ca-button-green-hover: var(--unraid-66-color);
 		--ca-legacy-background-color: var(--background-color,#e8e8e8);
 		--ca-search-modal-background: var(--ca-legacy-background-color);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/black.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/black.css
@@ -29,7 +29,7 @@
 	--ca-button-blue-hover: var(--unraid-66-color);
 	/* Green-button palette (.actionsUpdate). Same hover contract as
 	   the blue/red variants — lifts to brand orange. */
-	--ca-button-green: #2ca22c;
+	--ca-button-green: #1d8a1d;
 	--ca-button-green-hover: var(--unraid-66-color);
 	--ca-legacy-background-color: var(--background-color,#1d1b1b);
 	--ca-search-modal-background: gray;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/black.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/black.css
@@ -29,7 +29,7 @@
 	--ca-button-blue-hover: var(--unraid-66-color);
 	/* Green-button palette (.actionsUpdate). Same hover contract as
 	   the blue/red variants — lifts to brand orange. */
-	--ca-button-green: #1d8a1d;
+	--ca-button-green: #177817;
 	--ca-button-green-hover: var(--unraid-66-color);
 	--ca-legacy-background-color: var(--background-color,#1d1b1b);
 	--ca-search-modal-background: gray;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/gray.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/gray.css
@@ -29,7 +29,7 @@
 		--ca-button-blue-hover: var(--unraid-66-color);
 		/* Green-button palette (.actionsUpdate). Same hover contract as
 		   the blue/red variants — lifts to brand orange. */
-		--ca-button-green: #2ca22c;
+		--ca-button-green: #1d8a1d;
 		--ca-button-green-hover: var(--unraid-66-color);
 		--ca-legacy-background-color: var(--background-color,#1d1b1b);
 		--ca-search-modal-background: var(--ca-legacy-background-color);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/gray.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/gray.css
@@ -29,7 +29,7 @@
 		--ca-button-blue-hover: var(--unraid-66-color);
 		/* Green-button palette (.actionsUpdate). Same hover contract as
 		   the blue/red variants — lifts to brand orange. */
-		--ca-button-green: #1d8a1d;
+		--ca-button-green: #177817;
 		--ca-button-green-hover: var(--unraid-66-color);
 		--ca-legacy-background-color: var(--background-color,#1d1b1b);
 		--ca-search-modal-background: var(--ca-legacy-background-color);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/white.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/white.css
@@ -29,7 +29,7 @@
 	--ca-button-blue-hover: var(--unraid-66-color);
 	/* Green-button palette (.actionsUpdate). Same hover contract as
 	   the blue/red variants — lifts to brand orange. */
-	--ca-button-green: #1d8a1d;
+	--ca-button-green: #177817;
 	--ca-button-green-hover: var(--unraid-66-color);
 	--ca-legacy-background-color: var(--background-color,#f2f2f2);
 	--ca-search-modal-background: var(--ca-legacy-background-color);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/white.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/themes/white.css
@@ -29,7 +29,7 @@
 	--ca-button-blue-hover: var(--unraid-66-color);
 	/* Green-button palette (.actionsUpdate). Same hover contract as
 	   the blue/red variants — lifts to brand orange. */
-	--ca-button-green: #2ca22c;
+	--ca-button-green: #1d8a1d;
 	--ca-button-green-hover: var(--unraid-66-color);
 	--ca-legacy-background-color: var(--background-color,#f2f2f2);
 	--ca-search-modal-background: var(--ca-legacy-background-color);


### PR DESCRIPTION
## Summary

Replaces the nchan publish/subscribe approach for "another browser updated the feed" with a polling-style check, plus several related sidebar improvements.

## Cross-tab feed-update detection (polling, not push)

The old approach used an nchan publish on `ca_gettingTemplates` when a download completed, with subscribers in every open CA tab. Three problems with that:

1. **Stale buffered messages.** nchan delivered the last buffered message to new subscribers, so a fresh tab could pop the reload banner immediately for a publish that happened in a previously-closed tab.
2. **Shared-tabId filter false-positives.** The filter "skip my own publish if message equals my tabId" broke when two tabs shared sessionStorage (open-in-new-tab / duplicate-tab inherits the source's sessionStorage, including `ca_tabId`) — the second tab silently dropped legit foreign publishes too.
3. **Self-publish-suppression edge cases.** Counter / timestamp / boolean schemes all had race ordering issues (stale buffered messages, leaked counter slots, response-vs-publish ordering).

### New approach

- A dedicated per-tab marker file at `CA_PATHS['registeredTabs']/{tabId}` (= `$tempFiles/registeredID/{tabId}`). Touched-only, no content.
- New `registerTab` action JS calls once on tab boot. Server creates the marker.
- JS arms `window.caFeedTrackingArmed = true` in the `registerTab` done callback.
- `post()` helper attaches `caFeedCheck=true` to every subsequent request from a registered tab.
- `exec.php`'s pre-switch guard does a single `is_file()` check on the marker. If gone — which only happens when another tab triggered a download and wiped the entire `tempFiles/` tree — the guard short-circuits with `{feedUpdated: true}` and JS pops the reload banner.
- `DownloadApplicationFeed` re-registers the calling tab right before returning, so the driving tab stays in sync. Other tabs' markers are gone → banner on their next action.

Banner timing changes from "instant push" to "next thing the user does" on the stale tab — fine trade for losing zero events and eliminating the buffered-message + shared-tabId class of bugs.

## Sidebar pending-feed notice with live swap

When the sidebar opens before the background full-feed hydrate completes, the action button row shows **"Unavailable until feed downloads"** instead of buttons — Install / Reinstall / Install second / Edit all depend on Config blocks that only live in the full feed.

`hydrateFullFeed`'s JS callback now surgically swaps the `.popupStickyActions` block with freshly-rendered HTML the moment the hydrate finishes, so the buttons appear in place without a full sidebar reload or spinner flicker.

## Install-second hidden when Update available

`skin.php`'s action partition now drops `"Install second"` from the right-install bucket whenever the right-update bucket is non-empty. Installing a second instance of an app with a pending update would copy the old image anyway (`createXML` reads the same template).

## Pin moved from action row to support row

Pin slots into the support row just before any `ca_devMode` button (or at the end if none), grouping it with other passive on/off toggles. Drops the emission from `.popupStickyActions` and adds an icon-margin rule so the thumb-tack glyph keeps the same 0.5rem gap to its label in its new home.

## Other cleanups

- `writeGlobals()`'s `$signalReady` parameter removed. `force_update` only calls it on a fresh download now (no-download cycles skip `moderateTemplates()` + `writeGlobals()` entirely), so every caller is a real download — the parameter became dead.
- `signalFeedReady()` stripped down to just the `haveTemplates` touch (kept for `enableActionCentre`'s wait loop); the nchan publish is gone with the rest of the publish/subscribe machinery.
- `post()`'s self-publish suppression counter (`caFeedSelfTriggers`) removed — no nchan, no counter needed.
- `Apps.page`'s `NchanSubscriber` for `ca_gettingTemplates`, the 1.5s warmup `setTimeout`, the `SubReady` flag — all gone.

## Files

- `Apps.page` — bootstrap registers the tab via `postNoSpin({action:'registerTab'})`; `hydrateFullFeed` callback now surgically swaps the action row when the pending notice is visible; nchan subscriber code removed and replaced with a standalone `caHandleForeignFeedUpdate()` function.
- `include/exec.php` — pre-switch guard checking `caFeedCheck` + marker existence; `registerTab` case; `DownloadApplicationFeed` re-registers the calling tab; `force_update` only writes globals on fresh download.
- `include/helpers.php` — new `ensureTabRegistered()` helper; `writeGlobals()` simplified back to single-purpose; `signalFeedReady()` stripped to the sentinel touch.
- `include/paths.php` — new `'registeredTabs' => "$tempFiles/registeredID"` constant.
- `javascript/helpers.js` — `post()` attaches `caFeedCheck` to armed requests; done callback handles `feedUpdated:true` (banner + skip rest); self-publish counter removed.
- `skins/Narrow/skin.php` — action partition filters `Install second` when an Update is in the update bucket; Pin moved into the support row's render loop with dev-mode-aware positioning; pending notice block guards the action row when the full cache is missing.
- `skins/Narrow/styles/community.applications.css` — `.popupSupportRow .pinPopup::before` joins the icon-gap selector list; new `.popupStickyActions > .caFeedPending` styling for the pending notice.

No `.plg` bump. No `ca.md5` touch (regenerated by `copy_to_git.sh` but reverted before staging, per standing rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relocated sidebar "Pin" button to the support action row.
  * Sidebar sticky actions refresh in-place to keep buttons synced without a full reload.
  * Sidebar shows an italic "feed pending" message when feed data hasn't finished downloading.

* **Bug Fixes**
  * Cross-tab stale-feed reloads are now detected reliably and deferred while install/open modals are visible.
  * "Install second" is hidden when an update is available.

* **Style**
  * Updated green action button color across themes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->