### PR TITLE
fix: sidebar update button + language uninstall refresh

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Fixed: Plugin sidebar now shows the "Update" button when an update is available — the previous build silently dropped it on every sidebar open after the first
 - Changed: Sidebar "Pin" button moved from the action button row to the support button row (right before any dev-mode buttons) — declutters the action row and groups the toggle with the other passive on/off buttons
 - Changed: Sidebar action buttons show "Unavailable until feed downloads" when opened before the background full-feed hydrate completes — buttons appear in place automatically the moment the hydrate finishes
 - Changed: When an app has an Update available, the "Install second" button is hidden in the sidebar — installing a second instance while an update is pending would have copied the old image anyway

--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -24,6 +24,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 ## Unreleased
 
 - Fixed: Plugin sidebar now shows the "Update" button when an update is available — the previous build silently dropped it on every sidebar open after the first
+- Fixed: Uninstalling a language pack now refreshes the application list immediately — cards were stuck showing "Installed" until you navigated away and back (Action Centre was unaffected)
 - Changed: Sidebar "Pin" button moved from the action button row to the support button row (right before any dev-mode buttons) — declutters the action row and groups the toggle with the other passive on/off buttons
 - Changed: Sidebar action buttons show "Unavailable until feed downloads" when opened before the background full-feed hydrate completes — buttons appear in place automatically the moment the hydrate finishes
 - Changed: When an app has an Update available, the "Install second" button is hidden in the sidebar — installing a second instance while an update is pending would have copied the old image anyway

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -2807,10 +2807,21 @@ function postLanguageRefresh() {
 }
 
 /**
- * Simulate a menu click to repaint the current section after language removal.
+ * Refresh the current view after a language pack uninstall.
+ *
+ * The `trigger("click")` on selectedMenu re-fires the Action Centre handler
+ * (its `.sectionMenu` binding has no already-selected guard, so it re-runs
+ * actionCentre()). For every other category the `.caMenuItem`/`.categoryMenu`
+ * handlers early-return on the already-selected item, so the click is a
+ * no-op there — `refreshDisplay()` is what actually re-pulls
+ * `display_content` and re-evaluates `Installed` server-side. Matches
+ * postUninstallPlugin so card state stops going stale after uninstall.
  */
 function postLanguageRemove() {
+	enableSearch();
 	$(".selectedMenu").trigger("click");
+	setupActionCentre();
+	refreshDisplay(); /* chains caRefreshInstalledMenuStates */
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -553,17 +553,22 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 				/* `!=` (not `<`) is intentional: also fires when installed > feed,
 				   so a user can roll back to the feed version via the Update action. */
 				if ($template['installedVersion'] != $template['pluginVersion'] || (is_file("/tmp/plugins/$pluginName") && $template['installedVersion'] != ca_plugin("version","/tmp/plugins/$pluginName"))) {
-					if (is_file(CA_PATHS['pluginTempDownload'])) {
-						@copy(CA_PATHS['pluginTempDownload'],"/tmp/plugins/$pluginName");
-						$template['UpdateAvailable'] = true;
-						/* json_encode the string args so a hostile feed value can't break out
+					/* `@copy` is best-effort: pluginTempDownload may or may not be
+					   present (only the install/update flow stages it). When it's
+					   missing the copy no-ops; the Update button still emits so the
+					   sidebar matches the card's caProcessPluginTemplate path. The
+					   prior `is_file(...)` gate around this whole block was dead —
+					   nothing in the runtime produces pluginTempDownload during a
+					   plain sidebar open, so plugins never showed an Update action. */
+					@copy(CA_PATHS['pluginTempDownload'],"/tmp/plugins/$pluginName");
+					$template['UpdateAvailable'] = true;
+					/* json_encode the string args so a hostile feed value can't break out
 					   of the JS string literal — produces a properly-quoted JS string and
 					   escapes `<`/`>`/`&`/`'`/`"` for safety in the surrounding HTML
 					   attribute. The emit-side htmlspecialchars in skin.php is the
 					   second layer; this is the first. */
 					$pluginNameJs = json_encode($pluginName, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
 					$actionsContext[] = ["icon"=>"ca_fa-update","text"=>tr("Update"),"action"=>"installPlugin({$pluginNameJs},true);"];
-					}
 				} else {
 					$template['UpdateAvailable'] = false;
 				}


### PR DESCRIPTION
Two small sidebar-state refresh bugs in one branch.

## #1 — Plugin sidebar Update button
- `caBuildActionsContext` gated the plugin Update emit on `is_file(CA_PATHS['pluginTempDownload'])`, but the April refactor of `caFormatTemplateChanges` removed the only writer of that file during a sidebar open — so the gate was always false and plugins never showed the Update button on the sidebar
- Card view was unaffected (`caProcessPluginTemplate` has no such gate)
- Drop the gate so the sidebar mirrors the card path; `@copy` stays as a best-effort no-op for the install/update flow case

## #2 — Language pack uninstall display refresh
- `postLanguageRemove` only re-triggered click on `.selectedMenu`, but the `.caMenuItem`/`.categoryMenu` click handlers early-return when the clicked item is already selected — trigger no-oped, cards stayed stuck on "Installed"
- Action Centre survived only because its menu is `.sectionMenu` (different handler, no guard)
- Match `postUninstallPlugin`: keep the trigger (re-fires actionCentre when applicable), add `setupActionCentre()` + `refreshDisplay()` so `display_content` re-pulls and re-evaluates `is_dir(languageInstalled/...)` server-side

## Test plan
- [ ] Plugin with update pending: open sidebar, close, reopen → Update button shows on both opens
- [ ] Up-to-date plugin: no Update button (sidebar + card)
- [ ] Language pack uninstall from the Languages category → card flips from "Installed" to "Install" without navigating away
- [ ] Language pack uninstall from Action Centre → still refreshes (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Update" button not appearing in the plugin sidebar after opening it for the first time when an update is available.
  * Fixed language pack uninstallation where installed cards would remain stuck showing "Installed" status until navigating away; the app list now refreshes immediately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->