### PR TITLE
feat: full status-badge stack on cards + sidebar

### DIFF
--- a/.codex/coderabbit-fixes-wip.md
+++ b/.codex/coderabbit-fixes-wip.md
@@ -3,39 +3,33 @@
 ## Context
 
 - Repo: unraid/community.applications
-- Branch: feat/server-side-sidebar-fetch
-- PR: #55
-- PR URL: https://github.com/unraid/community.applications/pull/55
-- Generated at: 2026-05-23 (rebased on master after #54/#56/#58 merged)
+- Branch: feat/card-sidebar-badge-stack
+- PR: #73
+- PR URL: https://github.com/unraid/community.applications/pull/73
+- Generated at: 2026-05-25
 
 ## Inputs Pulled
 
-- [x] Unresolved CodeRabbit review threads pulled (2 items, addressed in earlier pass)
-- [x] Top-level CodeRabbit review notes pulled
+- [x] Unresolved CodeRabbit review threads pulled (1 item)
+- [x] Top-level CodeRabbit review notes pulled (1 review, no nitpicks)
 - [x] Top-level nitpicks extracted into queue (none)
 
 ## Fix Queue
 
 | Item ID | Type | File | Line | Summary | Status | Link | Evidence |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| CR-001 | thread | Apps.page | 3087-3095, 3182-3190 | postNoSpin Promise wrappers don't reject on transport failure — sidebar stuck in "Loading…" | DONE | https://github.com/unraid/community.applications/pull/55#discussion_r3291654064 | Both call sites swapped to `$.post(execURL, {…}).done().fail()` so transport errors reject the Promise and the existing catch surfaces the "can't be loaded" placeholder. tabId stamped manually since we're bypassing post()'s auto-stamping. |
-| CR-002 | thread | include/exec.php | 1918-1929 | `changes` cache key `{repoName}-{basename(url)}` can collide across distinct URLs sharing a basename | DONE | https://github.com/unraid/community.applications/pull/55#discussion_r3291654068 | Inserted an 8-char `substr(hash("sha256",$url),0,8)` between `$safeRepo` and `$base` so two URLs that share a basename within the same repo no longer hash to the same on-disk filename. `php -l` clean. |
+| CR-001 | thread | skins/Narrow/skin_helpers.php | 1925 | XSS — `VerMessage` from feed is interpolated raw into `title='{$verMsg}'`; single-quote in feed data breaks attribute, can execute script | DONE | https://github.com/unraid/community.applications/pull/73#discussion_r3299762340 | Wrapped `$template['VerMessage'] ?? <fallback>` in `htmlspecialchars(..., ENT_QUOTES, "UTF-8")` so any HTML metacharacters in feed data get encoded before landing in the badge `title=` attribute. Added comment block explaining why this is the only spot needing escape (all other badge titles use static `tr()` strings). `php -l` clean. |
 
 ## Execution Log
 
-### 1. CR-001 — postNoSpin → $.post with .fail() (Apps.page, both fetch sites)
-- Action: Replaced both `new Promise(...)` wrappers around `postNoSpin` (readme + changes) with `$.post(execURL, {…}).done(resolve-or-reject).fail(reject)`. Reason: `postNoSpin` only invokes its callback on the 2xx success path; transport failures (network down, non-2xx, JSON parse) left the Promise unsettled and the section stuck in the "Loading…" placeholder.
-- Validation: grep confirms no `postNoSpin.*caFetchSidebarSource` calls remain; both sites end in `.fail(function(){reject(new Error("transport failure"))})`.
-- Result: DONE
-
-### 2. CR-002 — exec.php cache key collision
-- Action: In `caFetchSidebarSource()` `kind === "changes"` branch, inserted `$urlHash = substr(hash("sha256",$url),0,8)` between `$safeRepo` and `$base`. New cache filename shape: `{safeRepo}-{urlHash}-{base}`. README path unchanged (1:1 with safeRepo by construction).
-- Validation: `php -l include/exec.php` clean.
+### 1. CR-001 — escape VerMessage before title-attr interpolation
+- Action: Wrapped the `VerMessage` resolution in `htmlspecialchars((string)($template['VerMessage'] ?? <fallback>), ENT_QUOTES, "UTF-8")`. `ENT_QUOTES` chosen so both `'` and `"` get encoded — the attribute uses single quotes today but the escape stays correct if that ever flips. Inline comment documents why this is the only feed-derived title in the badge stack (every other badge title is a static `tr()` call).
+- Validation: `php -l` clean. The `htmlspecialchars` call hardens the same XSS class CR identified — a hostile maintainer publishing `VerMessage="' onerror='..."` would now render the payload as inert text inside the title attribute instead of escaping the attribute context.
 - Result: DONE
 
 ## Final Checks
 
-- [x] Queue reviewed: no `TODO` left
-- [x] Remaining `BLOCKED` items documented with reason (none)
-- [x] Re-pulled CodeRabbit threads and reviews after first pass — both threads showed `isResolved: true`
-- [x] No unhandled top-level nitpick remains
+- [ ] Queue reviewed: no `TODO` left
+- [ ] Remaining `BLOCKED` items documented with reason
+- [ ] Re-pulled CodeRabbit threads and reviews
+- [ ] No unhandled top-level nitpick remains

--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,8 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: Cards show every applicable status badge (Installed + Updated, Incompatible + Deprecated, etc.) instead of only the highest-priority one — extra badges wrap to a second row inside the top-right corner without crossing the icon. Blacklist supersedes Deprecated and the LT-branded "Official" supersedes the plain "Official" so duplicate chips don't pile up
+- Added: Sidebar header now shows the same status badge row above the app icon — surfaces Installed / Updated / Incompatible / etc. without having to scroll the sidebar body
 - Fixed: Plugin sidebar now shows the "Update" button when an update is available — the previous build silently dropped it on every sidebar open after the first
 - Fixed: Uninstalling a language pack now refreshes the application list immediately — cards were stuck showing "Installed" until you navigated away and back (Action Centre was unaffected)
 - Changed: Sidebar "Pin" button moved from the action button row to the support button row (right before any dev-mode buttons) — declutters the action row and groups the toggle with the other passive on/off buttons

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -482,11 +482,16 @@ function displayPopup($template) {
 	   hostile template feed data — legitimate labels are plain strings
 	   from `tr()`. Also accepts the untranslated English variants so the
 	   detection survives a missing/partial locale file. */
+	/* "Reinstall" intentionally NOT here — for already-installed apps the
+	   primary action is Update (or Edit), and Reinstall is an auxiliary
+	   "rebuild from template" path. It lives in the LEFT group with Edit /
+	   WebUI / etc. so it doesn't visually compete with the primary blue
+	   install button. "Reinstall From Previous Apps" DOES stay on the
+	   right because in the Previous Apps section it IS the primary install
+	   action — only thing you can do on those cards besides Remove. */
 	$installFamilyTexts = [
-		tr("Install"), tr("Reinstall"),
-		tr("Install second"), tr("Reinstall From Previous Apps"),
-		"Install", "Reinstall",
-		"Install second", "Reinstall From Previous Apps",
+		tr("Install"), tr("Install second"), tr("Reinstall From Previous Apps"),
+		"Install", "Install second", "Reinstall From Previous Apps",
 	];
 	$updateFamilyTexts = [
 		tr("Update"),

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -541,6 +541,11 @@ function displayPopup($template) {
 			<?php if (! caIsDockerRunning() && (! $Plugin && ! $Language)): ?>
 				<div class='popupDockerDisabled'><?= tr("Docker Service Not Enabled - Only Plugins Available To Be Installed Or Managed") ?></div>
 			<?php endif; ?>
+			<?php /* Status badges sit above the icon/name block — same supersession
+			         rules as the card corner badges (caBuildSidebarFlag → shared
+			         caCollectBadges helper). Returns empty string when no badges
+			         apply, so the row collapses cleanly on plain templates. */ ?>
+			<?= caBuildSidebarFlag($template) ?>
 			<div class='ca_popupIconArea'>
 				<div class='popupIcon'><?= $display_icon ?></div>
 				<div class='popupInfo'>
@@ -1309,20 +1314,14 @@ function displayCard($template) {
 		";
 	}
 
-	if (!empty($template['Installed']) || !empty($template['Uninstall'])) {
-		$flagTextStart = tr("Installed")." · ";
-		$flagTextEnd = "";
-	} else {
-		$flagTextStart = "";
-		$flagTextEnd = "";
-	}
-
-	$cardFlag = caBuildCardFlag($template, $flagTextStart, $flagTextEnd);
+	$cardFlag = caBuildCardFlag($template);
 
 	$cardEnd = "</div>";
-	/* The corner-ribbon flag is rendered inside .ca_holder so it can position
+	/* The corner-badge stack is rendered inside .ca_holder so it can position
 	   absolutely against the card itself rather than relying on negative-margin
-	   sibling tricks against an outer wrapper. */
+	   sibling tricks against an outer wrapper. Stack renders all applicable
+	   badges, not just the highest-priority one — see caBuildCardFlag for the
+	   priority ordering and wrap behavior. */
 	$cardFinish = "{$cardStart}{$cardFlag}{$card}{$cardEnd}";
 
 	return str_replace(["\t", "\n"], "", $cardFinish);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -1876,96 +1876,118 @@ function caNormalizeOverview(array $template, string $name): string {
 }
 
 /**
- * Build the status flag/banner (installed, updated, etc.) for a template card.
+ * Collect all applicable status badges for a template, in priority order.
  *
- * Returns the first matching banner in priority order: UpdateAvailable, Installed,
- * Blacklist, caTemplateExists, Incompatible, Deprecated, Official, LTOfficial, Beta, Trusted.
+ * Shared helper backing both the card corner-badge stack and the sidebar
+ * header badge row — same supersession rules, same DOM order, different
+ * wrapper / positioning. Callers wrap the returned strings in whatever
+ * container suits their layout (`.cardFlagStack` for cards,
+ * `.sidebarFlagStack` for the sidebar).
  *
- * @param  array<string,mixed> $template      Template entry.
- * @param  string              $flagTextStart Prefix text for the banner body.
- * @param  string              $flagTextEnd   Suffix text for the banner body.
- * @return string HTML banner markup, or empty string if no flag applies.
+ * Priority order: UpdateAvailable, Installed, (Blacklist OR Deprecated),
+ * caTemplateExists, Incompatible, (LTOfficial OR Official), Beta, Trusted.
+ * Supersession pairs (`OR`) emit at most one badge each — Blacklist hides
+ * Deprecated, LTOfficial hides Official (LT-branded variant trumps plain).
+ *
+ * @param  array<string,mixed> $template Template entry.
+ * @return array<int,string> Ordered list of badge `<div>` HTML strings;
+ *                           empty array when no badges apply.
  */
-function caBuildCardFlag(array $template, string $flagTextStart, string $flagTextEnd): string {
+function caCollectBadges(array $template): array {
+	$badges = [];
+
 	if (!empty($template['UpdateAvailable'])) {
-		return "
-			<div class='betaCardBackground'>
-				<div class='installedCardText ca_center'>".tr("UPDATED")."</div>
-			</div>";
+		$badges[] = "<div class='betaCardBackground'><div class='installedCardText ca_center'>".tr("UPDATED")."</div></div>";
 	}
 
 	if ((!empty($template['Installed']) || !empty($template['Uninstall'])) && empty($template['actionCentre'])) {
-		return "
-			<div class='installedCardBackground'>
-				<div class='installedCardText ca_center'>".tr("INSTALLED")."</div>
-			</div>";
+		$badges[] = "<div class='installedCardBackground'><div class='installedCardText ca_center'>".tr("INSTALLED")."</div></div>";
 	}
 
+	/* Blacklist supersedes Deprecated — Blacklisted is the stronger
+	   moderator action (active removal-worthy) and Deprecated is the
+	   weaker "no longer maintained" signal. A Blacklisted app is
+	   implicitly past the point of "just deprecated", so showing both
+	   chips is noise. Incompatible can co-occur with either since it's
+	   an OS-version mismatch, not a maintainer judgement. */
 	if (!empty($template['Blacklist'])) {
-		return "
-			<div class='warningCardBackground'>
-				<div class='installedCardText ca_center' title='".tr("This application template has been blacklisted")."'>".tr("Blacklisted")."{$flagTextEnd}</div>
-			</div>
-		";
+		$badges[] = "<div class='warningCardBackground'><div class='installedCardText ca_center' title='".tr("This application template has been blacklisted")."'>".tr("Blacklisted")."</div></div>";
+	} elseif (!empty($template['Deprecated'])) {
+		$badges[] = "<div class='warningCardBackground'><div class='installedCardText ca_center' title='".tr("This application template has been deprecated")."'>".tr("Deprecated")."</div></div>";
 	}
 
 	if (!empty($template['caTemplateExists'])) {
-		return "
-			<div class='greenCardBackground'>
-				<div class='installedCardText ca_center' title='".tr("Template already exists in Apps")."'>".tr("Template")."</div>
-			</div>
-		";
+		$badges[] = "<div class='greenCardBackground'><div class='installedCardText ca_center' title='".tr("Template already exists in Apps")."'>".tr("Template")."</div></div>";
 	}
 
 	if (isset($template['Compatible']) && ! $template['Compatible']) {
 		$verMsg = $template['VerMessage'] ?? tr("This application is not compatible with your version of Unraid");
-
-		return "
-			<div class='warningCardBackground'>
-				<div class='installedCardText ca_center' title='{$verMsg}'>{$flagTextStart}".tr("Incompatible")."{$flagTextEnd}</div>
-			</div>
-		";
+		$badges[] = "<div class='warningCardBackground'><div class='installedCardText ca_center' title='{$verMsg}'>".tr("Incompatible")."</div></div>";
 	}
 
-	if (!empty($template['Deprecated'])) {
-		return "
-			<div class='warningCardBackground'>
-				<div class='installedCardText ca_center' title='".tr("This application template has been deprecated")."'>".tr("Deprecated")."{$flagTextEnd}</div>
-			</div>
-		";
-	}
-
-	if (!empty($template['Official'])) {
-		return "
-			<div class='officialCardBackground'>
-				<div class='installedCardText ca_center' title='".tr("This is an official container")."'>".tr("OFFICIAL")."</div>
-			</div>
-		";
-	}
-
+	/* LTOfficial supersedes Official — the LT (Lime Technology) variant
+	   carries the brand gradient and is a stronger claim than the plain
+	   "Official" purple chip. Showing both would just be redundant
+	   "OFFICIAL OFFICIAL" with no useful distinction. */
 	if (!empty($template['LTOfficial'])) {
-		return "
-			<div class='LTOfficialCardBackground'>
-				<div class='installedCardText ca_center' title='".tr("This is an official plugin")."'>".tr("OFFICIAL")."</div>
-			</div>
-		";
+		$badges[] = "<div class='LTOfficialCardBackground'><div class='installedCardText ca_center' title='".tr("This is an official plugin")."'>".tr("OFFICIAL")."</div></div>";
+	} elseif (!empty($template['Official'])) {
+		$badges[] = "<div class='officialCardBackground'><div class='installedCardText ca_center' title='".tr("This is an official container")."'>".tr("OFFICIAL")."</div></div>";
 	}
 
 	if (!empty($template['Beta'])) {
-		return "
-			<div class='betaCardBackground'>
-				<div class='installedCardText ca_center'>".tr("BETA")."</div>
-			</div>
-		";
+		$badges[] = "<div class='betaCardBackground'><div class='installedCardText ca_center'>".tr("BETA")."</div></div>";
 	}
 
 	if (!empty($template['Trusted'])) {
-		return "
-			<div class='spotlightCardBackground'>
-				<div class='installedCardText ca_center' title='".tr("This container is digitally signed")."'>".tr("Digitally Signed")."</div>
-			</div>
-		";
+		$badges[] = "<div class='spotlightCardBackground'><div class='installedCardText ca_center' title='".tr("This container is digitally signed")."'>".tr("Digitally Signed")."</div></div>";
 	}
 
-	return "";
+	return $badges;
+}
+
+/**
+ * Build the corner-badge stack for a template card.
+ *
+ * Emits ALL applicable badges (see {@link caCollectBadges} for the rules)
+ * inside `.cardFlagStack`, which positions the group top-right and flows
+ * additional badges leftward via `flex-direction: row-reverse` +
+ * `flex-wrap: wrap` in CSS. When the stack would overflow the card's safe
+ * zone (i.e. the icon's horizontal footprint), the remaining badges wrap
+ * to a new row below instead of disappearing behind the icon.
+ *
+ * DOM order = visual priority: first child sits in the top-right corner,
+ * lower-priority badges fill leftward.
+ *
+ * @param  array<string,mixed> $template Template entry.
+ * @return string HTML for `.cardFlagStack` wrapper + zero-or-more badges,
+ *                or empty string if no badges apply.
+ */
+function caBuildCardFlag(array $template): string {
+	$badges = caCollectBadges($template);
+	if (empty($badges)) return "";
+
+	return "<div class='cardFlagStack'>".implode("", $badges)."</div>";
+}
+
+/**
+ * Build the sidebar header badge row for a template popup.
+ *
+ * Same badge set / supersession rules as the card corner stack
+ * ({@link caCollectBadges}), but rendered as an in-flow row ABOVE the
+ * sidebar's icon/name block. Sidebar is wider than a card so the full
+ * width is available — single row by default, wraps to a second row if
+ * the user somehow accumulates enough concurrent flags (rare in practice).
+ *
+ * DOM order = visual priority: badges flow left-to-right.
+ *
+ * @param  array<string,mixed> $template Template entry.
+ * @return string HTML for `.sidebarFlagStack` wrapper + zero-or-more
+ *                badges, or empty string if no badges apply.
+ */
+function caBuildSidebarFlag(array $template): string {
+	$badges = caCollectBadges($template);
+	if (empty($badges)) return "";
+
+	return "<div class='sidebarFlagStack'>".implode("", $badges)."</div>";
 }

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -1921,7 +1921,19 @@ function caCollectBadges(array $template): array {
 	}
 
 	if (isset($template['Compatible']) && ! $template['Compatible']) {
-		$verMsg = $template['VerMessage'] ?? tr("This application is not compatible with your version of Unraid");
+		/* VerMessage is feed-derived (set by the appfeed for templates with
+		   custom incompatibility text). Every other badge title here is a
+		   static `tr()` string, so this is the one spot in the function that
+		   takes external input — and it lands inside a single-quoted HTML
+		   attribute. A hostile maintainer publishing `VerMessage="' onerror='..."`
+		   would otherwise close the attribute and inject script when the
+		   browser parses the badge. ENT_QUOTES so both `'` and `"` are escaped
+		   regardless of which delimiter the surrounding markup happens to use. */
+		$verMsg = htmlspecialchars(
+			(string)($template['VerMessage'] ?? tr("This application is not compatible with your version of Unraid")),
+			ENT_QUOTES,
+			"UTF-8"
+		);
 		$badges[] = "<div class='warningCardBackground'><div class='installedCardText ca_center' title='{$verMsg}'>".tr("Incompatible")."</div></div>";
 	}
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -2326,7 +2326,47 @@ input[type="button"] {
 		margin-top: 0px;
 	}
 
-	/* 3.11) Corner badges, pagination, and popup details */
+	/* 3.11) Corner badges, pagination, and popup details
+
+	   `.cardFlagStack` is the absolute-positioned wrapper that anchors the
+	   whole badge group in the card's top-right corner. Individual badges
+	   are flex items inside it — `row-reverse` keeps the highest-priority
+	   badge (first in DOM order) at the corner, with lower-priority badges
+	   filling leftward along the row. `flex-wrap: wrap` lets the stack drop
+	   to a new row BELOW when more badges than fit in `max-width` accumulate
+	   (rather than letting them slide left over the card icon).
+
+	   `max-width: 20rem` on a 36rem card leaves ~16rem of icon-safe space on
+	   the left. Anything beyond that wraps. */
+	.cardFlagStack {
+		position: absolute;
+		top: 0.75rem;
+		right: 0.75rem;
+		max-width: 20rem;
+		display: flex;
+		flex-direction: row-reverse;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		gap: 0.4rem;
+		z-index: 2;
+		pointer-events: none;
+	}
+	/* Sidebar variant: in-flow row above the icon/name block. No
+	   position:absolute (cards put the stack in the corner; sidebar
+	   wants it stacked vertically with the rest of the popup body),
+	   no max-width clamp (sidebar is wide enough that a single row
+	   handles the realistic badge count — wrap is just insurance for
+	   the rare case of many concurrent flags). Left-to-right reading
+	   order matches the rest of the sidebar typography. */
+	.sidebarFlagStack {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		gap: 0.4rem;
+		margin-bottom: 0.75rem;
+		pointer-events: none;
+	}
 	.officialCardBackground,
 	.LTOfficialCardBackground,
 	.spotlightCardBackground,
@@ -2334,9 +2374,6 @@ input[type="button"] {
 	.betaCardBackground,
 	.greenCardBackground,
 	.installedCardBackground {
-		position: absolute;
-		top: 0.75rem;
-		right: 0.75rem;
 		padding: 0.35rem 0.75rem;
 		border-radius: 0.4rem;
 		font-size: 1.1rem;
@@ -2346,8 +2383,8 @@ input[type="button"] {
 		font-weight: 600;
 		color: var(--ca-named-white);
 		pointer-events: none;
-		z-index: 2;
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+		white-space: nowrap;
 	}
 	.installedCardBackground {
 		background-color: var(--ca-purple-color);


### PR DESCRIPTION
## Summary
- Cards now render **every** applicable status badge instead of only the highest-priority one. Multi-flag templates (Installed + Updated, Incompatible + Deprecated, Beta + Official, etc.) used to collapse to a single chip; now each gets its own badge, with extra ones wrapping to a second row inside the top-right corner.
- Sidebar header gets the same badge row above the app icon — `caBuildSidebarFlag()` shares the badge collection / supersession logic with `caBuildCardFlag()` via the new `caCollectBadges()` helper, but uses a different in-flow wrapper (`.sidebarFlagStack`) instead of the corner-anchored `.cardFlagStack`.
- Supersession rules to keep duplicates from piling up:
  - **Blacklist ⊳ Deprecated** — Blacklist is the stronger moderator action; "no longer maintained" is implied
  - **LTOfficial ⊳ Official** — LT brand gradient supersedes the plain purple chip (otherwise you'd get two "OFFICIAL" chips next to each other)
- Incompatible deliberately co-occurs with anything — it's an OS-version mismatch, orthogonal to maintainer judgement.

## CSS layout
- `.cardFlagStack`: absolute top-right, `flex-direction: row-reverse` + `flex-wrap: wrap`, `max-width: 20rem` so overflow rows drop downward instead of sliding leftward over the card icon. First DOM child = top-right anchor.
- `.sidebarFlagStack`: in-flow row above `.ca_popupIconArea`, `flex-direction: row` (left-to-right reading order), no max-width — sidebar's width handles the realistic flag count in one row.

## Caller cleanup
`skin.php` drops the `$flagTextStart` / `$flagTextEnd` plumbing around the `caBuildCardFlag` call — those existed to splice `"Installed · "` into a combined badge label, which is no longer needed now that Installed renders as its own chip.

## Test plan
- [ ] Installed plugin with an update available: card + sidebar both show "UPDATED" + "INSTALLED" chips
- [ ] Blacklisted **and** Deprecated template: only the "Blacklisted" red chip renders (no separate "Deprecated")
- [ ] LT-official plugin (e.g. CA itself): only the gradient OFFICIAL chip (no separate purple OFFICIAL)
- [ ] Incompatible + Deprecated: both chips render side-by-side
- [ ] Plain template with no flags: no badge row on card or sidebar (no empty wrapper div)
- [ ] Card with several badges: extra ones wrap to a second row below the first inside the top-right corner; first row never extends past `max-width: 20rem` (well clear of the 8rem icon at the card's left)
- [ ] Sidebar with several badges: single row by default, wraps only when many flags concurrent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar header now shows the same status badge row above the app icon.
  * New "Incompatible" badge appears when an app is marked explicitly incompatible.

* **Changed**
  * App cards render multiple status badges with wrapping and priority-based precedence for clearer compatibility/availability info.
  * Install-popup action grouping adjusted so Reinstall is no longer grouped with install-family actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->