### PR TITLE
fix: key sidebar README cache by repo + app name; dev-mode feed SHA compare

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Fixed: Sidebar README cache now keys off both the repository and the app name, so two templates sharing a repo no longer serve each other's README from cache
 - Changed: Assorted UI tweaks across cards, sidebar, search popup, and diff overlay
 - Changed: Mobile / responsive layout improvements
 - Changed: CA now follows the active Unraid OS theme more strictly on 7.2+ — custom themes inherit automatically

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -3330,6 +3330,7 @@ function caLoadSidebarReadmeSections() {
 		var url = $section.attr("data-readme-url") || "";
 		var fallback = $section.attr("data-readme-url-fallback") || "";
 		var repoName = $section.attr("data-readme-repo") || "";
+		var appName = $section.attr("data-readme-app") || "";
 
 		/* Server-side fetch + cache. caIsPublicHttpUrlJs is still applied as
 		   a belt-and-braces gate — the backend re-validates with the stricter
@@ -3348,6 +3349,7 @@ function caLoadSidebarReadmeSections() {
 					action: "caFetchSidebarSource",
 					url: u,
 					repoName: repoName,
+					appName: appName,
 					kind: "readme",
 					noSpinner: true,
 					tabId: (typeof data !== "undefined" && data.tabId) ? data.tabId : ""

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -173,6 +173,9 @@ switch ($_POST['action']) {
 	case 'statistics':
 		statistics();
 		break;
+	case 'caCompareFeedShas':
+		caCompareFeedShas();
+		break;
 	case 'showModeration':
 		showModeration();
 		break;
@@ -604,10 +607,10 @@ function hydrateFullFeedWork(): string {
 
 	$downloadURL = randomFile();
 	$ApplicationFeed = download_json(CA_PATHS['application-feed'], $downloadURL, 600, false);
-	$label = "Primary Server (hydrate)";
+	$label = "Primary Server (full)";
 	if ( (! is_array($ApplicationFeed['applist'] ?? null)) || empty($ApplicationFeed['applist']) ) {
 		$ApplicationFeed = download_json(CA_PATHS['pluginProxy'].CA_PATHS['application-feedBackup'], $downloadURL, 600, false);
-		$label = "Backup Server (hydrate)";
+		$label = "Backup Server (full)";
 	}
 	/* Dev mode: stash the raw applicationFeed.json snapshot before
 	   deleting the per-request tempfile so the Diff/Plugin/Template
@@ -1860,10 +1863,66 @@ function statistics() {
 	$statistics['repositories'] = @count($repositories) ?: tr("unknown");
 	$statistics['updateTime'] = $updateTime;
 	$statistics['currentServer'] = tr($currentServer);
-	$statistics['primaryServerUrl'] = CA_PATHS['application-feed'];
-	$statistics['backupServerUrl'] = CA_PATHS['application-feedBackup'];
+
+	/* Dev/admin-only diagnostic: include the requesting tab's session id
+	   so the statistics popup can display it. Normal users get no tabId
+	   field in the response and the row in the template stays hidden. */
+	if (($GLOBALS['caSettings']['dev'] ?? "no") === "yes" && is_file(CA_PATHS['caAdmin'])) {
+		$statistics['tabId'] = (string)($_POST['tabId'] ?? '');
+	}
 
 	postReturn(['statistics'=>$statistics]);
+}
+
+/**
+ * Dev/admin-only diagnostic: fetch the three feed files (small, full,
+ * statistics) from both the primary CA server and the GitHub backup,
+ * compute SHA-256 of each body, and return per-file match results.
+ *
+ * Used by the bottom of the statistics popup (replaces the old
+ * Primary/Backup server links) so a maintainer can spot-check whether
+ * the two mirrors are in sync without leaving the GUI. Gated server-side
+ * on `caSettings['dev']` and the on-disk `caAdmin` marker so the action
+ * is a no-op for normal users.
+ *
+ * Returns:
+ *   { enabled: bool,
+ *     results: {
+ *       small:      { primary: <sha|null>, backup: <sha|null>, match: bool },
+ *       full:       { ... },
+ *       statistics: { ... }
+ *     }
+ *   }
+ * `null` sha values indicate the fetch failed for that URL.
+ *
+ * @return void
+ */
+function caCompareFeedShas() {
+	if (($GLOBALS['caSettings']['dev'] ?? "no") !== "yes" || !is_file(CA_PATHS['caAdmin'])) {
+		postReturn(['enabled' => false]);
+		return;
+	}
+
+	$sources = [
+		'small'      => ['primary' => CA_PATHS['application-feed-small'], 'backup' => CA_PATHS['application-feed-smallBackup']],
+		'full'       => ['primary' => CA_PATHS['application-feed'],       'backup' => CA_PATHS['application-feedBackup']],
+		'statistics' => ['primary' => CA_PATHS['statisticsURL'],          'backup' => CA_PATHS['statisticsURLBackup']],
+	];
+
+	$results = [];
+	foreach ($sources as $name => $urls) {
+		$primaryBody = download_url($urls['primary']);
+		$backupBody  = download_url($urls['backup']);
+		$primarySha  = (is_string($primaryBody) && strlen($primaryBody)) ? hash('sha256', $primaryBody) : null;
+		$backupSha   = (is_string($backupBody)  && strlen($backupBody))  ? hash('sha256', $backupBody)  : null;
+		$results[$name] = [
+			'primary' => $primarySha,
+			'backup'  => $backupSha,
+			'match'   => ($primarySha !== null && $backupSha !== null && $primarySha === $backupSha),
+		];
+	}
+
+	postReturn(['enabled' => true, 'results' => $results]);
 }
 
 /**
@@ -2043,10 +2102,12 @@ function getDevRawURL() {
  * Inputs (POST):
  *   url       Absolute https URL to fetch
  *   repoName  RepoName from the template entry (drives the cache file name)
+ *   appName   Template Name (folded into the readme cache file name so two
+ *             templates from the same repo don't share one README cache file)
  *   kind      "readme" or "changes"
  *
  * Cache file naming (under CA_PATHS['templates-community']):
- *   readme  → {alphaNumeric(repoName)}-README.md
+ *   readme  → {alphaNumeric(repoName . appName)}-README.md
  *   changes → {alphaNumeric(repoName)}-{sanitisedBasename(url)}   (preserves .plg / .xml)
  *
  * Response: { ok: true, content: "<file contents>" }
@@ -2057,6 +2118,7 @@ function getDevRawURL() {
 function caFetchSidebarSource() {
 	$url      = trim((string)getPost("url", ""));
 	$repoName = trim((string)getPost("repoName", ""));
+	$appName  = trim((string)getPost("appName", ""));
 	$kind     = (string)getPost("kind", "");
 
 	if ($url === "" || !caIsPublicHttpUrl($url)) {
@@ -2077,7 +2139,11 @@ function caFetchSidebarSource() {
 	}
 
 	if ($kind === "readme") {
-		$cacheName = $safeRepo . "-README.md";
+		/* Fold the app name into the cache key so two templates from the
+		   same repo (each pointing at its own README) don't share one cache
+		   file and serve each other's body. alphaNumeric() strips spaces
+		   and punctuation, leaving a filesystem-safe slug. */
+		$cacheName = alphaNumeric($safeRepo . $appName) . "-README.md";
 	} else {
 		$path = (string)parse_url($url, PHP_URL_PATH);
 		$base = basename($path);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -1538,13 +1538,14 @@ function caBuildReadmeSectionDiv(array $template): string {
 	$safeRawMainUrl = htmlspecialchars($rawMainUrl, ENT_QUOTES);
 	$safeRawMasterUrl = htmlspecialchars($rawMasterUrl, ENT_QUOTES);
 	$safeRepoName = htmlspecialchars((string)($template['RepoName'] ?? ""), ENT_QUOTES);
+	$safeAppName = htmlspecialchars((string)($template['Name'] ?? ""), ENT_QUOTES);
 	/* Loading placeholder rendered inside .ca_readme_body. JS replaces the
 	   whole inner DOM via .html(text) once the postNoSpin call completes, so
 	   it self-evicts on first paint and we don't have to hide it. */
 	$loadingReadme =
 		"<div class='ca_center caLogoIcon'></div>".
 		"<div class='ca_center ca_italic'>".tr("Loading README...")."</div>";
-	return "<div id='{$readmeId}' class='ReadmeSection popupDescription popup_readmore {$readmeId}' data-readme-id='{$readmeId}' data-readme-url='{$safeRawMainUrl}' data-readme-url-fallback='{$safeRawMasterUrl}' data-readme-repo='{$safeRepoName}'><div class='ReadmeSectionLabel ca_bold'><a class='popUpLink' href='{$safeReadmeUrl}' target='_blank' rel='noopener noreferrer'>".tr("View README on Web")."</a></div><div class='ca_readme_body'>{$loadingReadme}</div></div>";
+	return "<div id='{$readmeId}' class='ReadmeSection popupDescription popup_readmore {$readmeId}' data-readme-id='{$readmeId}' data-readme-url='{$safeRawMainUrl}' data-readme-url-fallback='{$safeRawMasterUrl}' data-readme-repo='{$safeRepoName}' data-readme-app='{$safeAppName}'><div class='ReadmeSectionLabel ca_bold'><a class='popUpLink' href='{$safeReadmeUrl}' target='_blank' rel='noopener noreferrer'>".tr("View README on Web")."</a></div><div class='ca_readme_body'>{$loadingReadme}</div></div>";
 }
 
 /**


### PR DESCRIPTION
## Summary

- **README cache fix**: Sidebar README cache was keyed only by `alphaNumeric(repoName)`, so two templates sharing a repo would overwrite each other's cache file and serve the wrong README on repeat sidebar opens. Cache key now folds the app name in (`alphaNumeric(repoName . appName)-README.md`), giving each template its own entry. App name is plumbed through via a new `data-readme-app` attribute on the placeholder div and an `appName` POST field on the `caFetchSidebarSource` call.
- **Dev-mode feed SHA compare**: New `caCompareFeedShas` action fetches the three feed files (small / full / statistics) from both the primary CA server and the GitHub backup, SHA-256s each body, and returns per-file match results. Gated server-side on `caSettings['dev'] === "yes"` + on-disk `caAdmin` marker so it's a no-op for normal users. Statistics popup also gets the requesting tab's session id in the response (dev-only) and drops the now-unused `primaryServerUrl` / `backupServerUrl` fields.
- **Misc**: Renames the `hydrateFullFeedWork` server labels from "(hydrate)" to "(full)" for clarity in the statistics popup.

## Test plan

- [ ] Open the sidebar for two templates that share the same `RepoName` but have different `Name` values; confirm each shows its own README content (not a swapped/cached body from the other)
- [ ] Inspect `/boot/config/plugins/community.applications/templates-community/` and confirm new cache files are named `{repo}{app}-README.md` with no spaces / punctuation
- [ ] Existing `{repo}-README.md` cache files become orphans — they'll be wiped on the next appfeed refresh; verify nothing breaks in the interim
- [ ] In dev mode with `caAdmin` marker present: open statistics popup, confirm the three feed-SHA rows render and "match" / "mismatch" reflect reality (pick a feed file to perturb on the backup mirror as a smoke test)
- [ ] In non-dev mode: confirm `caCompareFeedShas` action returns `{enabled:false}` and the statistics popup degrades gracefully (no broken UI from removed `primaryServerUrl` / `backupServerUrl` fields)
- [ ] Confirm `caFetchSidebarSource` still works when `appName` is empty (graceful degrade to repo-only cache key — fine for any legacy callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed README cache collisions when multiple templates share the same repository source, ensuring the correct README displays for each template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->