### PR TITLE
feat: sidebar gallery overhaul + plugin trend charts + last-month sort

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,17 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: Home page "Most Popular Plugins" row now ranks by *last month's* installs instead of lifetime downloads, and labels the row accordingly — surfaces what's actually catching on right now rather than perennial favorites
+- Added: Plugin sidebars now show the same Trend / Downloads-Per-Month / Total-Downloads charts that Docker container sidebars have, computed from the appfeed's monthly plugin install stats (rolling 11-month window ending at the last complete month — current month is excluded as partial data)
+- Added: Sidebar media gallery now includes a clickable thumbnail strip (carousel) at the bottom of the fullscreen popup when there's more than one screenshot/video — click any thumb to jump to that slide. The current slide's thumb is enlarged for easy tracking. Strip auto-hides on phone-sized or short viewports
+- Added: App / repo icons now open the sidebar media gallery (instead of a solo popup) so you can arrow / carousel through icon → screenshots → videos as one gallery. Icon isn't shown twice in the visible media row
+- Changed: Sidebar screenshots/videos appear above the README section instead of below, so visuals show up closer to the description
+- Changed: Sidebar screenshots whose URL exactly matches the app icon are now dropped — templates that listed the icon under Screenshot no longer paint a duplicate icon-as-thumbnail in the media row
+- Changed: Plugin trend-chart x-axis labels render as compact "Apr '26" style (no day number, year included so the year boundary is obvious)
+- Fixed: Sidebar gallery thumbnails that fail to load are now removed from the gallery entirely rather than swapped for a placeholder image — broken screenshots/videos no longer occupy slots in the carousel
+- Fixed: App / repo profile icons that fail to load keep the placeholder but are no longer clickable — clicking a question-mark icon used to open a fullscreen placeholder
+- Fixed: Sidebar media gallery from a previously-opened app no longer carries over its thumbnail strip when the next popup opens (e.g. clicking an app icon, or visiting an app with no media)
+- Fixed: Videos in the gallery attempt to resume from where you left off when arrow-navigating away and back in the same browser session (best-effort — only works for HTTPS Unraid GUIs and not protected/restricted YouTube videos)
 - Fixed: Sidebar README cache now keys off both the repository and the app name, so two templates sharing a repo no longer serve each other's README from cache
 - Changed: Assorted UI tweaks across cards, sidebar, search popup, and diff overlay
 - Changed: Mobile / responsive layout improvements

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -365,22 +365,271 @@ var ca_done_override = false;
 var caAutoplayVideos = caHasSetting("autoplayVideos");
 var caYtParams    = caAutoplayVideos ? "?autoplay=1&mute=1&playsinline=1" : "?playsinline=1";
 var caVimeoParams = caAutoplayVideos ? "?autoplay=1&muted=1" : "";
+
+/* ────────────────────────────────────────────────────────────────────────
+   YouTube resume-from-timestamp for MagnificPopup video galleries.
+
+   MFP destroys and rebuilds the iframe on every slide change (arrow keys,
+   click-next, etc.), so a YouTube video normally restarts from 0 each time
+   the user returns to it. We avoid that by:
+     1. Embedding `enablejsapi=1` (+ origin) in every YouTube iframe URL so
+        we can talk to the player via the IFrame API.
+     2. On each fresh iframe build (callbacks.change), lazy-loading the
+        YouTube IFrame API and wiring a `YT.Player` to the iframe element.
+     3. On `beforeChange` / `beforeClose`, reading `getCurrentTime()` from
+        the player that's still in the DOM and stashing it keyed by the
+        original video URL (data-mfp-src — `currItem.src`).
+     4. On the next render of the same URL, appending `&start=<seconds>`
+        to the embed URL so playback resumes where the user left off.
+   Vimeo (a separate JS API) isn't wired up — its videos continue to
+   restart, matching prior behavior. */
+window.caVideoTimes = window.caVideoTimes || {}; // origUrl  -> seconds
+window.caYTPlayers  = window.caYTPlayers  || {}; // iframeId -> { player, url }
+window.caYTApiReady = window.caYTApiReady || false;
+window.caYTApiQueue = window.caYTApiQueue || [];
+
+function caEnsureYTApi() {
+	if (document.getElementById("caYTApiScript")) return;
+	var s = document.createElement("script");
+	s.id  = "caYTApiScript";
+	s.src = "https://www.youtube.com/iframe_api";
+	document.head.appendChild(s);
+}
+/* Global ready hook called by the YouTube IFrame API once loaded. Drains
+   any attach requests queued before the API was available. */
+window.onYouTubeIframeAPIReady = function() {
+	window.caYTApiReady = true;
+	while (window.caYTApiQueue.length) window.caYTApiQueue.shift()();
+};
+
+function caAttachYTPlayer(iframeEl, origUrl) {
+	if (!iframeEl) return;
+	if (!iframeEl.id) iframeEl.id = "caYT_" + Date.now() + "_" + Math.floor(Math.random() * 1e6);
+	var setup = function() {
+		try {
+			var player = new YT.Player(iframeEl.id, {});
+			window.caYTPlayers[iframeEl.id] = { player: player, url: origUrl };
+		} catch (e) { /* iframe gone / not ready — harmless */ }
+	};
+	if (window.caYTApiReady) setup();
+	else { caEnsureYTApi(); window.caYTApiQueue.push(setup); }
+}
+
+function caCaptureActiveYTTime() {
+	/* MFP only renders one iframe at a time inside .mfp-iframe-scaler. */
+	var iframe = document.querySelector(".mfp-iframe-scaler iframe");
+	if (!iframe || !iframe.id) return;
+	var rec = window.caYTPlayers[iframe.id];
+	if (!rec || !rec.player || typeof rec.player.getCurrentTime !== "function") return;
+	try {
+		var t = rec.player.getCurrentTime();
+		if (typeof t === "number" && t > 0) window.caVideoTimes[rec.url] = t;
+	} catch (e) { /* player not fully ready — leave saved time as-is */ }
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+   Thumbnail strip for multi-item MFP galleries.
+
+   MFP only ships arrow nav + a counter — when a sidebar gallery has more
+   than one screenshot/video, render a clickable filmstrip pinned to the
+   bottom of the popup. Each thumb calls m.goTo(idx); the "active" class
+   tracks the current slide on every change. */
+function caMfpEnsureThumbStripStyles() {
+	if (document.getElementById("caMfpThumbStyles")) return;
+	var s = document.createElement("style");
+	s.id = "caMfpThumbStyles";
+	s.textContent =
+		".caMfpThumbs {" +
+			"position:absolute;left:0;right:0;bottom:5rem;" +
+			"display:flex;justify-content:center;align-items:flex-end;" +
+			"gap:1.5rem;" +
+			"padding:8px 12px;" +
+			"background:transparent;" +
+			"overflow:hidden;" + /* no scroll — flex shrink absorbs overflow */
+			"z-index:1100;" +
+		"}" +
+		/* flex:1 1 0 + min-width:0 lets every thumb shrink to share the
+		   strip width when there are many; max-width caps each thumb on
+		   roomy galleries so two-or-three thumb strips don't blow up to
+		   poster-sized. align-items:flex-end keeps everything sitting on
+		   the same baseline so the active (taller) thumb grows upward. */
+		".caMfpThumb {" +
+			"flex:1 1 0;min-width:0;max-width:8rem;" +
+			"height:56px;position:relative;" +
+			"cursor:pointer;border:2px solid transparent;" +
+			"opacity:0.55;" +
+			"transition:opacity .15s,border-color .15s,transform .15s,height .15s,max-width .15s;" +
+			"transform-origin:center bottom;" +
+			"background:#000;display:inline-block;overflow:hidden;" +
+		"}" +
+		/* object-fit:cover lets the image fill the variable-width thumb
+		   without distortion (vs. the prior width:auto which forced the
+		   thumb to grow to fit the image). */
+		".caMfpThumb img {width:100%;height:100%;display:block;object-fit:cover;}" +
+		".caMfpThumb:hover {opacity:1;transform:scale(1.08);}" +
+		/* Active thumb: taller AND wider than its peers so the current
+		   slide is obvious at a glance. flex:2 1 0 doubles its share of
+		   the strip width; max-width:12rem keeps it sane on big screens. */
+		".caMfpThumb.active {" +
+			"opacity:1;border-color:#ff8c2f;" +
+			"height:80px;flex:2 1 0;max-width:12rem;" +
+		"}" +
+		".caMfpThumb.active:hover {transform:scale(1.05);}" +
+		/* Play-icon overlay for video thumbs — reuses the same FA glyph
+		   and palette as the sidebar's .videoPlayOverlay so the
+		   affordance reads identically. Scaled down vs. the sidebar
+		   version since the thumb is only 56px tall. */
+		".caMfpThumb.caMfpThumbVideo::after {" +
+			"content:'\\f144';" +
+			"font-family:'fontAwesome';font-weight:900;" +
+			"position:absolute;top:50%;left:50%;" +
+			"transform:translate(-50%,-50%) scale(0.85);" +
+			"font-size:1.6em;" +
+			"color:rgba(255,255,255,0.9);" +
+			"text-shadow:1px 1px 3px rgba(0,0,0,0.7);" +
+			"pointer-events:none;" +
+			"transition:color .2s,transform .2s;" +
+		"}" +
+		".caMfpThumb.caMfpThumbVideo:hover::after {" +
+			"color:var(--brand-orange);" +
+			"transform:translate(-50%,-50%) scale(1);" +
+		"}" +
+		/* Reserve space at the bottom of the popup so the main content
+		   doesn't slide under the absolutely-positioned thumb strip.
+		   Math: 5rem bottom offset + ~96px strip (80px active thumb +
+		   16px padding) + ~1rem breathing room ≈ 12rem. */
+		".mfp-wrap.caHasThumbStrip .mfp-container {" +
+			"padding-bottom:12rem;" +
+		"}" +
+		/* MFP sets `max-height` on .mfp-img inline (resizeImage uses the
+		   window height, not the container's padded content area), so
+		   the container padding alone doesn't keep tall screenshots
+		   from overflowing under the strip. Cap to viewport minus the
+		   strip's reserved space, with !important to beat the inline. */
+		".mfp-wrap.caHasThumbStrip .mfp-figure img.mfp-img {" +
+			"max-height:calc(100vh - 14rem) !important;" +
+		"}";
+	document.head.appendChild(s);
+}
+
+function caMfpRenderThumbsStrip() {
+	var m = $.magnificPopup.instance;
+	if (!m || !m.wrap) return;
+	/* MFP keeps m.wrap detached between opens (rather than emptied), so any
+	   strip + reserve-space class from a prior open are still attached to
+	   it — strip both before deciding whether to draw a new one. */
+	m.wrap.find(".caMfpThumbs").remove();
+	m.wrap.removeClass("caHasThumbStrip");
+	if (!m.items || m.items.length < 2) return;
+	caMfpEnsureThumbStripStyles();
+	m.wrap.addClass("caHasThumbStrip");
+	var $strip = $("<div class='caMfpThumbs'></div>");
+	m.items.forEach(function(item, idx) {
+		if (!item.parsed) item = m.parseEl(idx);
+		var thumbSrc = "";
+		if (item.el && item.el.find) {
+			thumbSrc = item.el.find("img").attr("src") || "";
+		}
+		if (!thumbSrc && item.type === "image") thumbSrc = item.src;
+		var $thumb = $("<span class='caMfpThumb'></span>").attr("data-idx", idx);
+		/* iframe-type items are videos in this gallery — tag with the
+		   video-overlay class so the ::after play glyph paints on top. */
+		if (item.type === "iframe") $thumb.addClass("caMfpThumbVideo");
+		if (thumbSrc) {
+			$thumb.append($("<img referrerpolicy='no-referrer'>").attr("src", thumbSrc));
+		}
+		if (idx === m.index) $thumb.addClass("active");
+		$thumb.on("click", function(ev) {
+			ev.stopPropagation();
+			m.goTo(idx);
+		});
+		$strip.append($thumb);
+	});
+	m.wrap.append($strip);
+}
+
+function caMfpUpdateActiveThumb() {
+	var m = $.magnificPopup.instance;
+	if (!m || !m.wrap) return;
+	m.wrap.find(".caMfpThumb")
+		.removeClass("active")
+		.filter("[data-idx='" + m.index + "']")
+		.addClass("active");
+}
+
+/* Wraps a user-supplied callbacks object with the time-capture/attach hooks
+   (YouTube resume) plus the thumbnail-strip render/update so gallery
+   initializers can keep their own beforeOpen/afterClose etc. without
+   duplicating the plumbing. */
+function caWithVideoResumeCallbacks(userCbs) {
+	userCbs = userCbs || {};
+	var wrap = function(extra) {
+		return function() {
+			extra.apply(this, arguments);
+			var orig = userCbs[extra._name];
+			if (typeof orig === "function") orig.apply(this, arguments);
+		};
+	};
+	var onOpen = function() { caMfpRenderThumbsStrip(); };
+	onOpen._name = "open";
+	var onBeforeChange = function() { caCaptureActiveYTTime(); };
+	onBeforeChange._name = "beforeChange";
+	var onBeforeClose  = function() { caCaptureActiveYTTime(); };
+	onBeforeClose._name = "beforeClose";
+	var onChange = function() {
+		if (this.currItem && this.currItem.type === "iframe") {
+			var origUrl = this.currItem.src || "";
+			if (/youtube\.com|youtu\.be/.test(origUrl)) {
+				/* this.content is the MFP-managed jQuery wrapper around the
+				   freshly built `.mfp-iframe-scaler` div; at `change` time it
+				   may still be detached from the wrap container, so query
+				   inward off `this.content` rather than the global DOM. */
+				var iframe = this.content && this.content.find ? this.content.find("iframe")[0] : null;
+				if (iframe) caAttachYTPlayer(iframe, origUrl);
+			}
+		}
+		caMfpUpdateActiveThumb();
+	};
+	onChange._name = "change";
+	return $.extend({}, userCbs, {
+		open:         wrap(onOpen),
+		beforeChange: wrap(onBeforeChange),
+		change:       wrap(onChange),
+		beforeClose:  wrap(onBeforeClose)
+	});
+}
+
+/* Builds the "%id%" payload for the YouTube/youtu.be patterns. The MFP
+   embed URL is `//www.youtube.com/embed/<this>` (no trailing params), so
+   we stuff the full querystring into the id portion. caYtParams starts
+   with `?` (autoplay/mute/playsinline); we tack on enablejsapi=1, origin,
+   and a `&start=<sec>` resume hint when one is stashed for this URL. */
+function caBuildYouTubeIdParams(videoId, origUrl) {
+	var resume = window.caVideoTimes[origUrl]
+		? "&start=" + Math.floor(window.caVideoTimes[origUrl])
+		: "";
+	return videoId + caYtParams
+		+ "&enablejsapi=1"
+		+ "&origin=" + encodeURIComponent(location.origin)
+		+ resume;
+}
+
 var caMfpIframePatterns = {
 	youtube: {
 		index: "youtube.com/",
 		id: function(url) {
 			var m = url.match(/[?&]v=([A-Za-z0-9_-]+)/);
-			return m ? m[1] : url;
+			return caBuildYouTubeIdParams(m ? m[1] : url, url);
 		},
-		src: "//www.youtube.com/embed/%id%" + caYtParams
+		src: "//www.youtube.com/embed/%id%"
 	},
 	youtubeShort: {
 		index: "youtu.be/",
 		id: function(url) {
 			var m = url.match(/youtu\.be\/([A-Za-z0-9_-]+)/);
-			return m ? m[1] : url;
+			return caBuildYouTubeIdParams(m ? m[1] : url, url);
 		},
-		src: "//www.youtube.com/embed/%id%" + caYtParams
+		src: "//www.youtube.com/embed/%id%"
 	},
 	vimeo: {
 		index: "vimeo.com/",
@@ -3233,7 +3482,7 @@ function showSidebarApp(apppath,appname) {
 				gallery: { enabled: true, navigateByImgClick: true, preload: [0,1] },
 				zoom: { enabled: true, duration: 500, easing: 'ease-in-out' },
 				iframe: { patterns: caMfpIframePatterns },
-				callbacks: {
+				callbacks: caWithVideoResumeCallbacks({
 					beforeOpen: function() {
 						/* keepIdentity=true: afterClose below reopens the same
 						   sidebar via data.sidebarapp{path,name}, which the
@@ -3254,17 +3503,35 @@ function showSidebarApp(apppath,appname) {
 					afterClose: function() {
 						showSidebarApp(data.sidebarapppath,data.sidebarappname);
 					}
-				}
+				})
 			});
 			/* Stragglers — .screenshot elements that aren't part of a gallery
-			   (eg. the popup app icon) get a plain single-item popup. */
+			   (eg. the popup app icon) get a plain single-item popup.
+			   Run them through caWithVideoResumeCallbacks too: the wrapper
+			   is a no-op for single-item popups except that its `open` hook
+			   clears any leftover .caMfpThumbs / .caHasThumbStrip from a
+			   prior gallery's open — MFP keeps m.wrap detached between
+			   opens rather than empty, so without this hook the previous
+			   app's thumb strip would still be hanging off it. */
 			$('.screenshot').not($('.caMediaGallery').find('.screenshot')).magnificPopup({
 				type:'image',
 				closeMarkup: "<span class='mfp-close magnificPopup caButton caButtonLarge caButtonRed'>"+tr("CLOSE")+"</span>",
 				closeOnContentClick: true,
 				removalDelay: 100,
 				mainClass: 'mfp-fade',
-				zoom: { enabled: true, duration: 500, easing: 'ease-in-out' }
+				zoom: { enabled: true, duration: 500, easing: 'ease-in-out' },
+				callbacks: caWithVideoResumeCallbacks({})
+			});
+
+			/* App icon → open the media gallery at idx 0 (the hidden
+			   .caGalleryIconSeed tile). Lets the icon participate in arrow /
+			   carousel navigation alongside screenshots/videos without
+			   being painted twice in the visible media row. */
+			$('.caIconOpensGallery').off('click.caIconGallery').on('click.caIconGallery', function(ev) {
+				ev.preventDefault();
+				ev.stopPropagation();
+				var $gallery = $('.caMediaGallery');
+				if ($gallery.length) $gallery.magnificPopup('open', 0);
 			});
 			slideInSidebar();
 
@@ -3644,7 +3911,7 @@ function showRepoPopup(repository) {
 			gallery: { enabled: true, navigateByImgClick: true, preload: [0,1] },
 			zoom: { enabled: true, duration: 500, easing: 'ease-in-out' },
 			iframe: { patterns: caMfpIframePatterns },
-			callbacks: {
+			callbacks: caWithVideoResumeCallbacks({
 				beforeOpen: function() {
 					/* keepIdentity=true so afterClose's showRepoPopup() reopens
 					   to the same repo; without this, closeSidebar() would
@@ -3665,15 +3932,27 @@ function showRepoPopup(repository) {
 					$.cookie("sidebarAppPath",sidebarAppPath,{path:"/;SameSite=Lax"});
 					showRepoPopup(data.repository);
 				}
-			}
+			})
 		});
+		/* See app-popup straggler comment — caWithVideoResumeCallbacks
+		   is needed here too to clear any prior gallery's thumb strip
+		   leftover on the detached m.wrap. */
 		$('.screenshot').not($('.caMediaGallery').find('.screenshot')).magnificPopup({
 			type:'image',
 			closeMarkup: "<span class='mfp-close magnificPopup caButton caButtonLarge caButtonRed'>"+tr("CLOSE")+"</span>",
 			closeOnContentClick: true,
 			removalDelay: 100,
 			mainClass: 'mfp-fade',
-			zoom: { enabled: true, duration: 500, easing: 'ease-in-out' }
+			zoom: { enabled: true, duration: 500, easing: 'ease-in-out' },
+			callbacks: caWithVideoResumeCallbacks({})
+		});
+
+		/* Repo profile icon → open the gallery at idx 0 (hidden seed). */
+		$('.caIconOpensGallery').off('click.caIconGallery').on('click.caIconGallery', function(ev) {
+			ev.preventDefault();
+			ev.stopPropagation();
+			var $gallery = $('.caMediaGallery');
+			if ($gallery.length) $gallery.magnificPopup('open', 0);
 		});
 	});
 }

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -1041,7 +1041,7 @@ function appOfDay($file) {
 				if ( ! isset($template['trends']) ) continue;
 				if ( count($template['trends']) < 6 ) continue;
 				if ( startsWith($template['Repository'],"ich777/steamcmd") ) continue; // because a ton of apps all use the same repo
-				if ( $template['trending'] && ($template['downloads'] > 100000) ) {
+				if ( $template['trending'] && ( ($template['PluginURL']??false) || ($template['downloads'] > 100000) ) ) {
 					if ( checkRandomApp($template) ) {
 						if ( in_array($template['Repository'],$repos) )
 							continue;
@@ -1053,13 +1053,19 @@ function appOfDay($file) {
 			}
 			break;
 		case "topPlugins":
-			$sortOrder['sortBy'] = "downloads";
+			$previousMonth = date("m", strtotime("first day of previous month"));
+			foreach ($file as &$tplRef) {
+				if ( ! isset($tplRef['PluginURL']) ) continue;
+				$tplRef['lastMonthDownloads'] = (int)($tplRef['pluginStats'][$previousMonth] ?? 0);
+			}
+			unset($tplRef);
+			$sortOrder['sortBy'] = "lastMonthDownloads";
 			$sortOrder['sortDir'] = "Down";
 			usort($file,"mySort");
 			$repos = [];
 			foreach ($file as $template) {
 				if ( !isset($template['PluginURL']) ) continue;
-				if ( ! $template['downloads'] ?? false ) continue;
+				if ( ! ($template['lastMonthDownloads'] ?? 0) ) continue;
 
 				// don't show patch within top installs on home page if it's already installed and featured is displayed
 
@@ -1081,7 +1087,7 @@ function appOfDay($file) {
 			foreach ($file as $template) {
 				if ( isset($template['trends']) && count($template['trends'] ) < 3 ) continue;
 				if ( startsWith($template['Repository'],"ich777/steamcmd") ) continue; // because a ton of apps all use the same repo`
-				if ( isset($template['trending']) && ($template['downloads'] > 10000) ) {
+				if ( isset($template['trending']) && ( ($template['PluginURL']??false) || ($template['downloads'] > 10000) ) ) {
 					if ( checkRandomApp($template) ) {
 						if ( in_array($template['Repository'],$repos) )
 							continue;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/get_content_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/get_content_helpers.php
@@ -141,7 +141,7 @@ class GetContentHelpers {
 			[
 				"type"=>"topPlugins",
 				"text1"=>tr("Most Popular Plugins"),
-				"text2"=>tr("The most popular plugins installed by other Unraid users"),
+				"text2"=>tr("The most popular plugins installed by other Unraid users last month"),
 				"cat"=>"plugins:",
 				"sortby"=>"downloads",
 				"sortdir"=>"Down"

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -767,7 +767,7 @@ function mySort($a, $b) {
 	$b['trendDelta'] = $b['trendDelta'] ?? null;
 	if ( $sortOrder['sortBy'] == "Name" )
 		$sortOrder['sortBy'] = "SortName";
-	if ( $sortOrder['sortBy'] != "downloads" && $sortOrder['sortBy'] != "trendDelta") {
+	if ( $sortOrder['sortBy'] != "downloads" && $sortOrder['sortBy'] != "trendDelta" && $sortOrder['sortBy'] != "lastMonthDownloads") {
 		$c = strtolower($a[$sortOrder['sortBy']] ?? "");
 		$d = strtolower($b[$sortOrder['sortBy']] ?? "");
 	} else {
@@ -840,16 +840,101 @@ function searchArray($array,$key,$value,$startingIndex=0) {
 	return false;
 }
 /**
+ * Synthesize docker-style trend arrays for plugin templates from `pluginStats`.
+ *
+ * pluginStats is a calendar-year map of MM => monthly install count plus
+ * `T` (lifetime total). Dockers ship pre-baked `trends` / `trendsDate` /
+ * `downloadtrend`; plugins don't, so we compute equivalents here so the
+ * sidebar's Trend / Downloads-Per-Month / Total-Downloads charts (gated only
+ * on those fields being populated) light up for plugins too.
+ *
+ * Strategy: walk a rolling window of up to 11 completed months ending at the
+ * previous month (11 not 12 — the MM keys are year-agnostic, so going a full
+ * 12 back would alias to the current partial month's key). Anchor the latest
+ * cumulative on `T - currentMonthInstalls` and walk backwards subtracting
+ * each month's installs. Pre-window history (anything older than the window)
+ * collapses into the first point so the cumulative chart reflects real
+ * lifetime growth. Iteration stops once we cross FirstSeen.
+ *
+ * @param  array<string,mixed>  $template  Mutated in place.
+ * @return void
+ */
+function computePluginTrendsFromStats(&$template) {
+	if ( ! ($template['PluginURL'] ?? false) ) return;
+	if ( ! is_array($template['pluginStats'] ?? null) ) return;
+
+	$stats = $template['pluginStats'];
+	$total = (int)($stats['T'] ?? 0);
+	if ( $total <= 0 ) return;
+
+	$currentYear  = (int)date('Y');
+	$currentMonth = (int)date('n');
+	$firstSeen    = (int)($template['FirstSeen'] ?? 0);
+	$firstSeenYear  = $firstSeen ? (int)date('Y', $firstSeen) : 0;
+	$firstSeenMonth = $firstSeen ? (int)date('n', $firstSeen) : 0;
+
+	/* pluginStats uses MM-only keys, so the same key is reused every year.
+	   We can safely walk up to 11 months back from the last completed month
+	   — going 12 back would collide with the current (partial) month's key.
+	   Current month itself is excluded (partial data). */
+	$points = []; // [['year'=>Y,'month'=>M], ...] oldest-last
+	for ( $i = 1; $i <= 11; $i++ ) {
+		$ts = mktime(0, 0, 0, $currentMonth - $i, 1, $currentYear);
+		$y = (int)date('Y', $ts);
+		$m = (int)date('n', $ts);
+		if ( $firstSeen && ($y < $firstSeenYear || ($y === $firstSeenYear && $m < $firstSeenMonth)) ) {
+			break; // earlier than FirstSeen — stop walking back
+		}
+		$points[] = ['year' => $y, 'month' => $m];
+	}
+	if ( count($points) < 2 ) return;
+	$points = array_reverse($points); // chronological
+
+	$monthly = [];
+	$dates   = [];
+	foreach ( $points as $p ) {
+		$monthly[] = (int)($stats[sprintf('%02d', $p['month'])] ?? 0);
+		$dates[]   = mktime(0, 0, 0, $p['month'], 1, $p['year']);
+	}
+
+	/* T includes the current (excluded) partial month — back it out so the
+	   final cumulative anchors on end-of-previous-month. */
+	$currentMonthInstalls = (int)($stats[sprintf('%02d', $currentMonth)] ?? 0);
+	$anchor = max(0, $total - $currentMonthInstalls);
+
+	$cumulative = array_fill(0, count($monthly), 0);
+	$running    = $anchor;
+	for ( $i = count($monthly) - 1; $i >= 0; $i-- ) {
+		$cumulative[$i] = max(0, $running);
+		$running       -= $monthly[$i];
+	}
+
+	$trends = [];
+	foreach ( $monthly as $i => $cnt ) {
+		$cum      = $cumulative[$i];
+		$trends[] = $cum > 0 ? round(($cnt / $cum) * 100, 3) : 0;
+	}
+
+	$template['trends']        = $trends;
+	$template['trendsDate']    = $dates;
+	$template['downloadtrend'] = $cumulative;
+	$template['trending']      = end($trends);
+}
+
+/**
  * Repair common template authoring mistakes so the rest of the pipeline can trust the row.
  *
  * Fixes default MinVer, derives Date/BrandNewApp, normalizes Deprecated /
  * Blacklist into real booleans, applies DeprecatedMaxVer, and clears
- * boilerplate "Container Path:" descriptions from Config entries.
+ * boilerplate "Container Path:" descriptions from Config entries. Also
+ * synthesizes plugin-side trend arrays from pluginStats so the sidebar
+ * charts work for plugins (see computePluginTrendsFromStats).
  *
  * @param  array<string,mixed>  $template
  * @return array<string,mixed>
  */
 function fixTemplates($template) {
+	computePluginTrendsFromStats($template);
 
 	if ( ! $template['MinVer'] ) $template['MinVer'] = ($template['Plugin']??false) ? "6.1" : "6.0";
 	if ( ! ($template['Date']??null) ) $template['Date'] = (is_numeric($template['DateInstalled']??null)) ? $template['DateInstalled'] : 0;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -767,7 +767,7 @@ function mySort($a, $b) {
 	$b['trendDelta'] = $b['trendDelta'] ?? null;
 	if ( $sortOrder['sortBy'] == "Name" )
 		$sortOrder['sortBy'] = "SortName";
-	if ( $sortOrder['sortBy'] != "downloads" && $sortOrder['sortBy'] != "trendDelta" && $sortOrder['sortBy'] != "lastMonthDownloads") {
+	if ( $sortOrder['sortBy'] != "downloads" && $sortOrder['sortBy'] != "trendDelta" && $sortOrder['sortBy'] != "lastMonthDownloads" && $sortOrder['sortBy'] != "trending") {
 		$c = strtolower($a[$sortOrder['sortBy']] ?? "");
 		$d = strtolower($b[$sortOrder['sortBy']] ?? "");
 	} else {

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -1495,17 +1495,58 @@ function caInitializeEventHandlers() {
 	 * Capture-phase error handler that substitutes a placeholder image when
 	 * any `<img>` fails to load (spotlight icons get their dedicated backup).
 	 *
+	 * Sidebar gallery thumbs (`.caMediaGallery .screenshot img`) are special-
+	 * cased: a broken screenshot/video poster almost always means the source
+	 * URL is dead, so the whole `.screenshot` tile is dropped from the
+	 * gallery rather than replaced with a question-mark image — keeps the
+	 * MFP gallery (and the new thumbnail strip) from showing dead entries.
+	 * If removing the tile empties the gallery, hide it entirely.
+	 *
 	 * @param {ErrorEvent} event
 	 */
 	window.addEventListener("error", function(event) {
 		var target = event.target;
-		if (target && target.tagName === "IMG") {
-			if (target.classList.contains("spotlightIcon")) {
-				target.src = window.caSpotlightIconBackup || "/plugins/dynamix.docker.manager/images/question.png";
-			} else {
-				target.src = "/plugins/dynamix.docker.manager/images/question.png";
-			}
+		if (!target || target.tagName !== "IMG") return;
+
+		var $screenshot = $(target).closest(".caMediaGallery .screenshot");
+		if ($screenshot.length) {
+			var $gallery = $screenshot.closest(".caMediaGallery");
+			$screenshot.remove();
+			if (!$gallery.find(".screenshot").length) $gallery.hide();
 			target.onerror = null;
+			return;
+		}
+
+		if (target.classList.contains("spotlightIcon")) {
+			target.src = window.caSpotlightIconBackup || "/plugins/dynamix.docker.manager/images/question.png";
+		} else {
+			target.src = "/plugins/dynamix.docker.manager/images/question.png";
+		}
+		target.onerror = null;
+
+		/* Replaced-with-question icons aren't worth fullscreening — strip
+		   the .screenshot/.mfp-image classes and the magnificPopup click
+		   binding so the placeholder isn't a live MFP trigger. Two markup
+		   shapes hit this path:
+		     - app/repo icon: <img class='popupIcon caIconOpensGallery' ...>
+		     - legacy .screenshot wrapper inside the popup body
+		   For the straggler `.screenshot` popups MFP binds the click
+		   directly on the element (no delegate), so removing the class
+		   alone isn't enough — `.off("click.magnificPopup")` peels the
+		   handler off too. caIconOpensGallery uses our own namespaced
+		   binding `click.caIconGallery` (added in Apps.page); strip that
+		   too along with the class so the placeholder doesn't open the
+		   gallery to a broken seed. */
+		var $mfpRoot = $(target).hasClass("screenshot")
+			? $(target)
+			: $(target).closest(".screenshot");
+		if ($mfpRoot.length) {
+			$mfpRoot.off("click.magnificPopup");
+			$mfpRoot.removeClass("screenshot mfp-image");
+			$mfpRoot.removeAttr("data-mfp-src");
+		}
+		if ($(target).hasClass("caIconOpensGallery")) {
+			$(target).off("click.caIconGallery").removeClass("caIconOpensGallery");
 		}
 	}, true);
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -308,47 +308,64 @@ function displayPopup($template) {
 
 	$mediaBlock = "";
 	$pictures = $Screenshot ?: $Photo;
-	if ($pictures || $Video) {
-		$mediaSections = [];
-		if ($pictures) {
-			foreach ($pictures as $shot) {
-				$shot = trim($shot);
-				/* caIsPublicHttpUrl instead of validURL — popup images auto-fetch
-				   on render, so the stricter LAN/.local/RFC1918 rejection that
-				   guards the popup icon at line 873 has to apply here too.
-				   referrerpolicy='no-referrer' only hides the referrer; it
-				   doesn't stop the request itself. */
-				if ($shot === "" || !caIsPublicHttpUrl($shot)) {
-					continue;
-				}
-				$safeShot = htmlspecialchars($shot, ENT_QUOTES);
-				/* span (not <a>) so the legacy external-link click handler doesn't
-				   intercept this — magnific uses data-mfp-src as the source. */
-				$mediaSections[] = "<span class='screenshot mfp-image' data-mfp-src='$safeShot'><img class='screen' src='$safeShot' referrerpolicy='no-referrer'></img></span>";
+	$iconUrlNormalized = trim((string)($Icon ?? ""));
+	$iconForGallery   = ($iconUrlNormalized !== "" && caIsPublicHttpUrl($iconUrlNormalized)) ? $iconUrlNormalized : "";
+	$mediaSections    = [];
+
+	/* Hidden icon seed: keeps the app icon as a real gallery item (clickable
+	   via the icon area at the top of the popup, plus reachable via the
+	   carousel/arrows once the gallery is open) without painting a duplicate
+	   tile in the visible media row. The visible icon's click handler opens
+	   the gallery at index 0 (this seed). */
+	if ($iconForGallery !== "") {
+		$safeSeed = htmlspecialchars($iconForGallery, ENT_QUOTES);
+		$mediaSections[] = "<span class='screenshot mfp-image caGalleryIconSeed' data-mfp-src='$safeSeed' style='display:none'><img class='screen' src='$safeSeed' referrerpolicy='no-referrer'></span>";
+	}
+
+	if ($pictures) {
+		foreach ($pictures as $shot) {
+			$shot = trim($shot);
+			/* caIsPublicHttpUrl instead of validURL — popup images auto-fetch
+			   on render, so the stricter LAN/.local/RFC1918 rejection that
+			   guards the popup icon at line 873 has to apply here too.
+			   referrerpolicy='no-referrer' only hides the referrer; it
+			   doesn't stop the request itself. */
+			if ($shot === "" || !caIsPublicHttpUrl($shot)) {
+				continue;
 			}
-		}
-		if ($Video) {
-			foreach ($Video as $vid) {
-				$vid = trim($vid);
-				if ($vid === "" || !caIsPublicHttpUrl($vid)) {
-					continue;
-				}
-				$thumbnail = trim((string)getYoutubeThumbnail($vid));
-				/* The youtube thumbnail comes from a fixed-format helper, but it's
-				   still derived from a feed-supplied URL — gate it with the same
-				   public-URL check so an attacker-controlled video URL can't
-				   produce a thumbnail src pointing at a LAN host. */
-				if ($thumbnail === "" || !caIsPublicHttpUrl($thumbnail)) {
-					continue;
-				}
-				$safeVid = htmlspecialchars($vid, ENT_QUOTES);
-				$safeThumb = htmlspecialchars($thumbnail, ENT_QUOTES);
-				$mediaSections[] = "<span class='screenshot mfp-iframe videoPlayOverlay' data-mfp-src='$safeVid' style='position: relative; display: inline-block;'><img class='screen' src='$safeThumb' referrerpolicy='no-referrer'></span>";
+			/* Skip screenshots that duplicate the app's icon — some
+			   templates reuse the icon URL in the Screenshot list,
+			   which renders as an awkward thumbnail of the icon. */
+			if ($iconUrlNormalized !== "" && $shot === $iconUrlNormalized) {
+				continue;
 			}
+			$safeShot = htmlspecialchars($shot, ENT_QUOTES);
+			/* span (not <a>) so the legacy external-link click handler doesn't
+			   intercept this — magnific uses data-mfp-src as the source. */
+			$mediaSections[] = "<span class='screenshot mfp-image' data-mfp-src='$safeShot'><img class='screen' src='$safeShot' referrerpolicy='no-referrer'></img></span>";
 		}
-		if ($mediaSections) {
-			$mediaBlock = "<div class='caMediaGallery'>".implode("", $mediaSections)."</div>";
+	}
+	if ($Video) {
+		foreach ($Video as $vid) {
+			$vid = trim($vid);
+			if ($vid === "" || !caIsPublicHttpUrl($vid)) {
+				continue;
+			}
+			$thumbnail = trim((string)getYoutubeThumbnail($vid));
+			/* The youtube thumbnail comes from a fixed-format helper, but it's
+			   still derived from a feed-supplied URL — gate it with the same
+			   public-URL check so an attacker-controlled video URL can't
+			   produce a thumbnail src pointing at a LAN host. */
+			if ($thumbnail === "" || !caIsPublicHttpUrl($thumbnail)) {
+				continue;
+			}
+			$safeVid = htmlspecialchars($vid, ENT_QUOTES);
+			$safeThumb = htmlspecialchars($thumbnail, ENT_QUOTES);
+			$mediaSections[] = "<span class='screenshot mfp-iframe videoPlayOverlay' data-mfp-src='$safeVid' style='position: relative; display: inline-block;'><img class='screen' src='$safeThumb' referrerpolicy='no-referrer'></span>";
 		}
+	}
+	if ($mediaSections) {
+		$mediaBlock = "<div class='caMediaGallery'>".implode("", $mediaSections)."</div>";
 	}
 
 	$appType = $Plugin ? tr("Plugin") : tr("Docker");
@@ -725,9 +742,9 @@ function displayPopup($template) {
 			<div class='popupDescription popup_readmore'><?= $display_ovr ?></div>
 			<?= $CACommentBlock ?>
 			<?= $RequiresMessage ?>
+			<?= $mediaBlock ?>
 			<?= $readmeSection ?>
 			<?= $RecommendedBlock ?>
-			<?= $mediaBlock ?>
 			<?= $chartBlock ?>
 			<div>
 				<div class='popupInfoSection'>
@@ -1061,9 +1078,15 @@ function getPopupDescriptionSkin($appNumber) {
 		   `Icon=http://192.168.1.1/admin/reboot` could otherwise CSRF a LAN
 		   device. Anything that fails falls back to the local "?" image. */
 		$iconCandidate = (string)$template['Icon'];
-		$safeIcon = caIsPublicHttpUrl($iconCandidate) ? $iconCandidate : "/plugins/dynamix.docker.manager/images/question.png";
+		$iconIsPublic = caIsPublicHttpUrl($iconCandidate);
+		$safeIcon = $iconIsPublic ? $iconCandidate : "/plugins/dynamix.docker.manager/images/question.png";
 		$safeIconAttr = htmlspecialchars($safeIcon, ENT_QUOTES);
-		$template['display_icon'] = "<img class='popupIcon screenshot' href='{$safeIconAttr}' src='{$safeIconAttr}' alt='Application Icon' referrerpolicy='no-referrer'>";
+		/* When the icon is a real public-HTTP URL we tag it caIconOpensGallery
+		   instead of .screenshot — JS in Apps.page binds the click to open
+		   .caMediaGallery's MFP at index 0 (the hidden icon seed). Fallback
+		   question.png icons get neither class so they aren't clickable. */
+		$iconClass = $iconIsPublic ? "popupIcon caIconOpensGallery" : "popupIcon";
+		$template['display_icon'] = "<img class='{$iconClass}' src='{$safeIconAttr}' alt='Application Icon' referrerpolicy='no-referrer'>";
 	}
 
 	$template['ModeratorComment'] = caApplySidebarSearchLinks($template['ModeratorComment']);
@@ -1127,10 +1150,13 @@ function getRepoDescriptionSkin($repository) {
 	/* caIsPublicHttpUrl, not validURL — repo icon auto-fetches on popup open
 	   so the same LAN-host rejection that guards the popup / card icons has
 	   to apply here too. */
-	$safeIconUrl = ($iconUrl && caIsPublicHttpUrl($iconUrl)) ? htmlspecialchars($iconUrl, ENT_QUOTES) : "";
-	$iconPrefix = $safeIconUrl ? "<span class='screenshot mfp-image' data-mfp-src='{$safeIconUrl}'>" : "";
-	$iconPostfix = $safeIconUrl ? "</span>" : "";
+	$iconIsPublic = ($iconUrl && caIsPublicHttpUrl($iconUrl));
+	$safeIconUrl = $iconIsPublic ? htmlspecialchars($iconUrl, ENT_QUOTES) : "";
 	$repoIcon = $safeIconUrl ?: "/plugins/dynamix.docker.manager/images/question.png";
+	/* Same pattern as the app popup: real public icons become gallery
+	   triggers (caIconOpensGallery → MFP open at idx 0 of the hidden seed),
+	   question-mark fallbacks stay non-clickable. */
+	$iconClass = $iconIsPublic ? "popupIcon caIconOpensGallery" : "popupIcon";
 	$repoBio = isset($repo['bio']) ? markdown($repo['bio']) : "<br><center>".tr("No description present");
 	$favRepoClass = ($GLOBALS['caSettings']['favourite'] == $repository) ? "fav" : "nonfav";
 	$encodedRepository = htmlentities($repository, ENT_QUOTES);
@@ -1138,7 +1164,7 @@ function getRepoDescriptionSkin($repository) {
 	$totals = caSummarizeRepositoryTemplates($templates, $repository);
 
 	$donationSection = caBuildRepoDonationSection($repo);
-	$mediaSection = caBuildRepoMediaSection($repo);
+	$mediaSection = caBuildRepoMediaSection($repo, $iconIsPublic ? (string)$iconUrl : "");
 	$linksSection = caBuildRepoLinkSection($repo);
 	$statsSection = caBuildRepoStatsSection($repo, $totals);
 
@@ -1156,7 +1182,7 @@ function getRepoDescriptionSkin($repository) {
 		<div class='popupContent'>
 			<div class='ca_popupIconArea'>
 				<div class='popupIcon'>
-					$iconPrefix<img class='popupIcon' src='{$repoIcon}' referrerpolicy='no-referrer'>$iconPostfix
+					<img class='{$iconClass}' src='{$repoIcon}' referrerpolicy='no-referrer'>
 				</div>
 				<div class='popupInfo'>
 					<div class='popupName ellipsis'>$repository</div>

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -351,16 +351,19 @@ function displayPopup($template) {
 			if ($vid === "" || !caIsPublicHttpUrl($vid)) {
 				continue;
 			}
+			/* getYoutubeThumbnail() only returns a poster for youtube.com /
+			   youtu.be URLs; Vimeo (and any other iframe MFP supports via
+			   caMfpIframePatterns in Apps.page) returns empty. We still
+			   want the tile to render and be openable in MFP — fall back
+			   to the local question.png poster instead of dropping the
+			   item. The public-URL gate stays on the thumbnail only when
+			   we got one, so a feed-supplied URL still can't point the
+			   poster at a LAN host. */
 			$thumbnail = trim((string)getYoutubeThumbnail($vid));
-			/* The youtube thumbnail comes from a fixed-format helper, but it's
-			   still derived from a feed-supplied URL — gate it with the same
-			   public-URL check so an attacker-controlled video URL can't
-			   produce a thumbnail src pointing at a LAN host. */
-			if ($thumbnail === "" || !caIsPublicHttpUrl($thumbnail)) {
-				continue;
-			}
 			$safeVid = htmlspecialchars($vid, ENT_QUOTES);
-			$safeThumb = htmlspecialchars($thumbnail, ENT_QUOTES);
+			$safeThumb = ($thumbnail !== "" && caIsPublicHttpUrl($thumbnail))
+				? htmlspecialchars($thumbnail, ENT_QUOTES)
+				: "/plugins/dynamix.docker.manager/images/question.png";
 			$mediaSections[] = "<span class='screenshot mfp-iframe videoPlayOverlay' data-mfp-src='$safeVid' style='position: relative; display: inline-block;'><img class='screen' src='$safeThumb' referrerpolicy='no-referrer'></span>";
 		}
 	}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -382,8 +382,11 @@ function caPrepareTrendVisuals(array &$template, &$templateDescription) {
 		}
 
 		if (isset($template['trendsDate'])) {
-			array_walk($template['trendsDate'],function (&$entry) {
-				$entry = tr(date("M",$entry),0).date(" j",$entry);
+			$isPlugin = (bool)($template['PluginURL'] ?? false);
+			array_walk($template['trendsDate'],function (&$entry) use ($isPlugin) {
+				$entry = $isPlugin
+					? tr(date("M",$entry),0).date(" \\'y",$entry)
+					: tr(date("M",$entry),0).date(" j",$entry);
 			});
 		}
 
@@ -1184,19 +1187,33 @@ function caBuildRepoDonationSection(array $repo): string {
  * Build the media (photos/videos) section for repository popups.
  *
  * Resolves YouTube thumbnails via getYoutubeThumbnail() for video tiles.
+ * When $iconUrl is a non-empty public-HTTP URL, the gallery is seeded with
+ * a hidden tile at index 0 so the popup's profile-icon click can open the
+ * MFP gallery at that point (icon appears in the carousel/arrow flow but
+ * not as a visible tile in the inline media row).
  *
- * @param  array<string,mixed> $repo Repository metadata containing Photo/Video entries.
- * @return string HTML media gallery markup, or empty string if no media.
+ * @param  array<string,mixed> $repo    Repository metadata containing Photo/Video entries.
+ * @param  string              $iconUrl Optional repo profile icon URL to seed the gallery with.
+ * @return string HTML media gallery markup, or empty string if no media + no icon seed.
  */
-function caBuildRepoMediaSection(array $repo): string {
+function caBuildRepoMediaSection(array $repo, string $iconUrl = ""): string {
 	$hasPhoto = !empty($repo['Photo']);
 	$hasVideo = !empty($repo['Video']);
+	$seedIcon = ($iconUrl !== "" && caIsPublicHttpUrl($iconUrl)) ? $iconUrl : "";
 
-	if (! $hasPhoto && ! $hasVideo) {
+	if (! $hasPhoto && ! $hasVideo && $seedIcon === "") {
 		return "";
 	}
 
 	$mediaHtml = "<div class='caMediaGallery'>";
+
+	if ($seedIcon !== "") {
+		/* Hidden seed — same pattern as the app popup's mediaBlock. Lets the
+		   profile icon click open the gallery at idx 0 without painting a
+		   duplicate tile in the visible media row. */
+		$safeSeed = htmlspecialchars($seedIcon, ENT_QUOTES);
+		$mediaHtml .= "<span class='screenshot mfp-image caGalleryIconSeed' data-mfp-src='{$safeSeed}' style='display:none'><img class='screen' src='{$safeSeed}' referrerpolicy='no-referrer'></span>";
+	}
 
 	if ($hasPhoto) {
 		$photos = is_array($repo['Photo']) ? $repo['Photo'] : [$repo['Photo']];
@@ -1206,6 +1223,9 @@ function caBuildRepoMediaSection(array $repo): string {
 			   render, same threat surface as the popup gallery in skin.php. */
 			if ($shot === "" || !caIsPublicHttpUrl($shot)) {
 				continue;
+			}
+			if ($seedIcon !== "" && $shot === $seedIcon) {
+				continue; // don't duplicate the icon as a visible tile
 			}
 			$safeShot = htmlspecialchars($shot, ENT_QUOTES);
 			/* span (not <a>) so the legacy external-link click handler doesn't

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -1241,15 +1241,16 @@ function caBuildRepoMediaSection(array $repo, string $iconUrl = ""): string {
 			if ($vid === "" || !caIsPublicHttpUrl($vid)) {
 				continue;
 			}
+			/* Same fallback as the app-popup mediaBlock: keep the tile
+			   for non-YouTube iframes (Vimeo etc.) where getYoutubeThumbnail
+			   returns empty, using a local placeholder poster. The
+			   caIsPublicHttpUrl gate still applies to any derived thumbnail
+			   URL so a feed-supplied value can't smuggle in a LAN host. */
 			$thumbnail = trim((string)getYoutubeThumbnail($vid));
-			/* Gate the thumbnail too — derived from a feed-supplied video URL,
-			   so a hostile maintainer could otherwise smuggle a LAN host through
-			   the thumbnail src even though the video URL passed the public check. */
-			if ($thumbnail === "" || !caIsPublicHttpUrl($thumbnail)) {
-				continue;
-			}
 			$safeVid = htmlspecialchars($vid, ENT_QUOTES);
-			$safeThumb = htmlspecialchars($thumbnail, ENT_QUOTES);
+			$safeThumb = ($thumbnail !== "" && caIsPublicHttpUrl($thumbnail))
+				? htmlspecialchars($thumbnail, ENT_QUOTES)
+				: "/plugins/dynamix.docker.manager/images/question.png";
 			$mediaHtml .= "<span class='screenshot mfp-iframe videoPlayOverlay' data-mfp-src='{$safeVid}' style='position: relative; display: inline-block;'><img class='screen' src='{$safeThumb}' referrerpolicy='no-referrer'></span>";
 		}
 	}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -2520,6 +2520,13 @@ input[type="button"] {
 		border-radius: 1rem 1rem 1rem 1rem;
 	}
 
+	/* The icon img used to carry the .screenshot class (cursor:pointer
+	   came from that). Now that real icons get .caIconOpensGallery to
+	   open the media gallery instead, re-add the pointer affordance. */
+	.caIconOpensGallery {
+		cursor: pointer;
+	}
+
 	.popupInfo {
 		flex: 1;
 		min-width: 0;             /* allow ellipsis on .popupName inside flex item */

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
@@ -361,6 +361,21 @@ body:has(.ca_useWholeDisplayWindow) {
 		display: none;
 	}
 
+	/* MagnificPopup gallery thumbnail strip — phone viewports don't have
+	   the horizontal room for a useful filmstrip, and reserving 10rem of
+	   bottom height (see .caHasThumbStrip in Apps.page) eats the slide
+	   itself. Drop the strip + its reserve so the slide takes the full
+	   popup area; left/right arrows still cycle. */
+	.caMfpThumbs {
+		display: none !important;
+	}
+	.mfp-wrap.caHasThumbStrip .mfp-container {
+		padding-bottom: 0 !important;
+	}
+	.mfp-wrap.caHasThumbStrip .mfp-figure img.mfp-img {
+		max-height: 100vh !important;
+	}
+
 }
 @media (max-height: 600px) {
 	#header {
@@ -369,5 +384,17 @@ body:has(.ca_useWholeDisplayWindow) {
 
 	.Theme--nav-top .ca_display_area {
 		bottom: 0;
+	}
+
+	/* Same reasoning as the max-width: 767px block above — short
+	   viewports can't spare the 10rem reserve for the filmstrip. */
+	.caMfpThumbs {
+		display: none !important;
+	}
+	.mfp-wrap.caHasThumbStrip .mfp-container {
+		padding-bottom: 0 !important;
+	}
+	.mfp-wrap.caHasThumbStrip .mfp-figure img.mfp-img {
+		max-height: 100vh !important;
 	}
 }


### PR DESCRIPTION
## Summary

- **Most Popular Plugins row** now ranks by **last month's** installs (`pluginStats[MM-1]`) rather than lifetime `T`. Caption updated to "…installed last month."
- **Plugin sidebar charts** — Trend / Downloads-Per-Month / Total-Downloads, computed from the appfeed's monthly plugin install stats. Rolling 11-month window ending at the last complete month (MM keys are year-agnostic — 12 back would alias the current-month key); `T − currentMonthInstalls` anchors the latest cumulative so the in-progress month doesn't leak in. X-axis labels render compact, e.g. `Apr '26`.
- **Gallery filmstrip carousel** at the bottom of the MFP popup whenever there's >1 item. Click-to-jump, active thumb enlarges and grows upward via `align-items:flex-end`, video thumbs get a play-circle overlay (re-using the sidebar's `.videoPlayOverlay` glyph). Strip self-hides on phone (<768px) and short (<600px) viewports.
- **App + repo icons join the gallery** — clicking the icon opens MFP at index 0 of a hidden `.caGalleryIconSeed` tile, so the icon is reachable via arrow keys + carousel without painting a duplicate tile in the visible media row. Question-mark placeholder icons are now correctly *not* clickable.
- **Sidebar layout**: media block moved above the README section. Screenshots whose URL matches the icon are filtered.
- **Broken-image policy**: gallery thumbs that 404 are removed from the gallery (auto-hides if emptied); icon imgs that 404 keep the placeholder visible but lose all click bindings.
- **YouTube resume (best-effort)**: each embed gets `enablejsapi=1` + `origin`, the IFrame Player API is lazy-loaded, `getCurrentTime()` is captured on `beforeChange`/`beforeClose` and replayed via `&start=…` on the next render. HTTPS-only in practice (postMessage from `http://unraid.local/` to `youtube.com` is blocked); falls back gracefully when it can't.
- **Home page plugin gates** — the `> 100000` (topperforming) and `> 10000` (trending) download thresholds are bypassed for plugins, since plugin install counts never approach docker pull totals.

## Test plan

- [ ] Home row "Most Popular Plugins" lists by previous month's installs (e.g. visit during May → ranks by `04` key); caption says "…installed last month"
- [ ] Plugin sidebar with monthly data shows three charts (Trend / Downloads Per Month / Total Downloads), x-axis labels formatted `Mmm 'YY`
- [ ] Plugin first seen mid-year only shows points from its first month onward
- [ ] Gallery with ≥2 items shows the bottom filmstrip; click thumb jumps; active thumb is taller/wider; video thumbs have the play overlay; arrow keys + strip stay in sync
- [ ] Gallery with 1 item (or sub-thresholds — narrow viewport or short viewport) does **not** show the filmstrip; full popup area is reclaimed
- [ ] App icon click → MFP opens at the icon, arrow-right cycles through screenshots/videos; the icon is **not** also a visible tile in the inline media row
- [ ] Repo profile-icon click → same behavior using the repo's photos/videos
- [ ] Question-mark placeholder icons (icon URL absent or non-public): icon stays visible, **not** clickable, no broken seed in gallery
- [ ] Screenshot whose 4xx response triggers the global error handler: tile vanishes from the inline gallery + MFP carousel; if it was the only item, `.caMediaGallery` hides entirely
- [ ] Navigate to an app with multi-item gallery → close MFP → click that app's icon (or visit another app and open its icon) → no stale filmstrip from the previous gallery
- [ ] HTTPS Unraid GUI + watchable YouTube video: play, ➡ to a screenshot, ⬅ back → resumes near previous playback time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YouTube videos resume where you left off in galleries
  * Thumbnail strip UI for multi-item galleries
  * "Most Popular Plugins" re-ranked by last month's installs
  * Plugin sidebars show trend and download charts; trend x-axis labels improved
  * App and repo icons open media galleries; expanded sidebar media gallery

* **Bug Fixes**
  * Fixed gallery thumbnail/carousel behavior and popup thumbnail carryover
  * Fixed icon clickability on image load failure; removed duplicate icon thumbnails
  * Improved sidebar screenshot placement and presentation

* **Style**
  * Cursor affordance added for gallery-opening icons

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/community.applications/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->