### PR TITLE
feat: sidebar media tiles — 16:9 video frame + 2× hover zoom

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -24,6 +24,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 ## Unreleased
 
 - Changed: Sidebar video thumbnails/previews are now shown in a 16:9 frame (the natural video shape) instead of being cropped to the screenshot tile's aspect
+- Changed: Hovering a sidebar screenshot or video now enlarges it to twice its size (was a slight 1.2× zoom for screenshots)
 
 - Added: Videos in an app's sidebar now autoplay a muted, looping preview right in the thumbnail. Clicking still opens the full-size player (which stays paused until you press play). The separate "Autoplay videos" setting has been removed — sidebar previews are always on now
 - Fixed: Dev-mode "Diff" button now works for plugins — it was comparing against the plugin's install file instead of its template, so it never found a match

--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,8 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: Sidebar video thumbnails/previews are now shown in a 16:9 frame (the natural video shape) instead of being cropped to the screenshot tile's aspect
+
 - Added: Videos in an app's sidebar now autoplay a muted, looping preview right in the thumbnail. Clicking still opens the full-size player (which stays paused until you press play). The separate "Autoplay videos" setting has been removed — sidebar previews are always on now
 - Fixed: Dev-mode "Diff" button now works for plugins — it was comparing against the plugin's install file instead of its template, so it never found a match
 - Fixed: When "Limit search results" narrows everything away, the "ALL RESULTS" link no longer floats off to the side of "No Matching Applications Found" — it now sits on its own line beneath a "Settings limited the search results." note

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -3288,7 +3288,7 @@ input[type="button"] {
 	}
 
 	.screen:hover {
-		transform: scale(1.2);
+		transform: scale(2);
 		transition: transform 0.3s ease;
 		z-index: 10;
 		position: relative;
@@ -4714,6 +4714,20 @@ input[type="button"] {
 		/* JS sizes this to the poster's border-box; keep our own border inside
 		   that box so we don't overhang the tile by 2px. */
 		box-sizing: border-box;
+		transition: transform 0.3s ease;
+	}
+
+	/* Hovering a video tile scales the live preview 2× to match the
+	   screenshot hover (.screen:hover). The poster img is visibility:hidden
+	   once the iframe mounts, so .screen:hover never fires for video tiles —
+	   we scale the iframe instead. z-index on the (position:relative) tile
+	   lifts the enlarged preview above neighbouring tiles. Scale is from the
+	   center, so the var-positioned play icon stays centered. */
+	.screenshot.mfp-iframe:hover {
+		z-index: 10;
+	}
+	.screenshot.mfp-iframe:hover .caInlineVideoPreview {
+		transform: scale(2);
 	}
 
 	/* Video Play Overlay */

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -3294,6 +3294,20 @@ input[type="button"] {
 		position: relative;
 	}
 
+	/* Video tiles are forced to a 16:9 box (the natural video frame) rather
+	   than the poster's own aspect. Height stays the shared 8rem; aspect-ratio
+	   derives the width (≈14.2rem), overriding .screen's 8–12rem clamp.
+	   object-fit:cover fills the box without letterboxing. The inline preview
+	   iframe is sized from this img's box in caMountInlineVideoPreviews(), so
+	   it inherits 16:9 automatically. */
+	.screenshot.mfp-iframe img.screen {
+		aspect-ratio: 16 / 9;
+		width: auto;
+		min-width: 0;
+		max-width: none;
+		object-fit: cover;
+	}
+
 	.screenshot {
 		cursor: pointer;
 	}


### PR DESCRIPTION
## Summary

Two related sidebar media-tile presentation tweaks.

### 16:9 video frame (fix)
The video poster `<img>` (and the inline preview iframe sized from it) was using the screenshot tile's box — `min-width:8rem; max-width:12rem; height:8rem` — cropping the video to an arbitrary aspect. Video tiles are now pinned to `aspect-ratio: 16 / 9` at the shared `8rem` height (width derives to ≈14.2rem), with `object-fit: cover` so the poster fills the frame without letterboxing. `caMountInlineVideoPreviews()` already sizes the iframe and re-centers the play icon from the poster's box, so both inherit 16:9 with no JS change. Scoped to `.screenshot.mfp-iframe img.screen` — photos untouched.

### 2× hover zoom (feat)
Hovering a screenshot or video now enlarges it to **2×** (screenshots were a subtle 1.2×).
- Screenshots: `.screen:hover` scale bumped `1.2 → 2`.
- Videos need a separate rule: the poster img is `visibility:hidden` once the inline preview mounts, so `.screen:hover` never fires. We scale the `.caInlineVideoPreview` iframe instead and raise the (position:relative) tile's `z-index` so the enlarged preview lifts above neighbouring tiles. Scale is from center, so the var-positioned play icon stays centered.

## Testing
Verified by inspection. Worth a quick look in a running sidebar: 16:9 tiles, hover zoom to 2× on both screenshots and videos, play icon stays centered on the enlarged video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Sidebar video thumbnails/previews now display in a natural 16:9 frame, improving visual consistency and reducing awkward cropping.
  * Hovering a sidebar screenshot or video now enlarges the preview to 2× (up from 1.2×), and images scale more cleanly within their tiles for a smoother browsing experience.

* **Documentation**
  * Changelog updated under Unreleased to note the 16:9 frame and enlarged hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->