### PR TITLE
fix: template-install error flash and spotlight info-area width

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,8 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Fixed: Installing an app from a template no longer briefly flashes an error (most noticeable in Firefox) — a background request was being cancelled as the page navigated and reported as a failure
+- Fixed: The spotlight app's info area now spans the full available width
 - Changed: The Apps browser now uses your browser's native scrollbar instead of a custom one — its length reflects the full number of matching apps, and you can click or drag it to jump straight to any point in the list. Scrolling a large catalogue stays smooth, and moving to the end no longer loads everything at once
 - Chore: Renamed the hidden browser-back helper page (CA_notices.page → ca_browser_back_helper.page) to better reflect what it does
 - Changed: The status-message area now sits inline just before the page footer instead of pinned to the bottom-left corner

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -3245,10 +3245,6 @@ function caReadSavedState() {
  */
 function saveState() {
 	if (data.ignoreUnload) return;
-	/* Leaving /Apps for a child page or unload — drop the docker info cache
-	   so whatever happens off-page (install/edit/uninstall) doesn't return
-	   to a stale snapshot. */
-	if (typeof caDropInfoCache === "function") caDropInfoCache();
 	var isHome = !$("#templates_content .ca_templatesDisplay").length;
 	var state = {
 		v: 1,

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -3737,6 +3737,7 @@ input[type="button"] {
 	}
 
 	.spotlightInfoArea {
+		width: 100%;
 		margin-left: 2rem;
 		padding-left: 10rem;
 		margin-top: 2rem;


### PR DESCRIPTION
Two small fixes, independent of each other.

## Fix 1 — error flash when installing from a template

`saveState()` ran `caDropInfoCache()` whenever leaving /Apps. Installing an app from a template navigates the page, which aborts that in-flight `dropInfoCache` POST; the request's `.fail` handler then fires and briefly flashes an error (most noticeable in Firefox). Removed that call from `saveState()` (the other `caDropInfoCache()` call sites still cover their own flows), along with the now-stale comment above it.

## Fix 2 — spotlight info area width

`.spotlightInfoArea` now gets `width: 100%` so it spans the full available width.

## Files
- `Apps.page` — remove `caDropInfoCache()` from `saveState()`
- `skins/Narrow/styles/community.applications.css` — `.spotlightInfoArea { width: 100% }`
- `plugins/CHANGES.md` — two user-facing bullets

## Test plan
- Install an app from a template in Firefox — no error flash on navigation.
- Check the spotlight app's info area fills the width as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Installing an app from a template no longer briefly displays an error message during the installation process
- Spotlight app's info area now properly spans the full available width of the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->