### PR TITLE
feat: scrollbar styling and grow-on-interaction

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Changed: The app browser's scrollbars now stay visible as a slim marker and thicken while you hover or scroll the area
 - Changed: The Apps browser now uses your browser's native scrollbar instead of a custom one — its length reflects the full number of matching apps, and you can click or drag it to jump straight to any point in the list. Scrolling a large catalogue stays smooth, and moving to the end no longer loads everything at once
 - Chore: Renamed the hidden browser-back helper page (CA_notices.page → ca_browser_back_helper.page) to better reflect what it does
 - Changed: The status-message area now sits inline just before the page footer instead of pinned to the bottom-left corner

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -17,13 +17,74 @@ SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 /**
+ * Grow the native scrollbar on a pane while it is hovered or scrolled.
+ *
+ * WebKit won't restyle a `::-webkit-scrollbar` from the container's `:hover`
+ * state alone — it only repaints the bar when the bar itself redraws — so a
+ * pure-CSS hover grow is unreliable on static panes. Toggling a class instead
+ * invalidates style thoroughly enough that the bar repaints on both enter and
+ * leave. The stylesheet grows the thumb for `.ca_bar_active`; this just manages
+ * the class from hover + scroll, returning the bar to its slim state a short
+ * time after interaction stops.
+ */
+function caInitScrollbarActivity() {
+	var SELECTOR = ".menuItems, .sidenav, .ca_homeTemplates, .mainArea, .ca_diffCol";
+	var IDLE_MS = 700;
+	var idleTimers = new WeakMap();
+
+	var clearIdle = function(el) {
+		var t = idleTimers.get(el);
+		if (t) { clearTimeout(t); idleTimers.delete(el); }
+	};
+	var activate = function(el) {
+		if (!el || !el.classList) return;
+		clearIdle(el);
+		el.classList.add("ca_bar_active");
+	};
+	var deactivateSoon = function(el) {
+		if (!el || !el.classList) return;
+		clearIdle(el);
+		idleTimers.set(el, setTimeout(function() {
+			idleTimers.delete(el);
+			/* Stay grown while the pointer is still over the pane. */
+			if (!(el.matches && el.matches(":hover"))) el.classList.remove("ca_bar_active");
+		}, IDLE_MS));
+	};
+	var paneFrom = function(node) {
+		return (node && node.closest) ? node.closest(SELECTOR) : null;
+	};
+
+	/* Scroll doesn't bubble, so catch it in the capture phase. Covers wheel /
+	   trackpad gestures, which never trigger :hover. */
+	document.addEventListener("scroll", function(e) {
+		var el = e.target;
+		if (el && el.nodeType === 1 && el.matches && el.matches(SELECTOR)) {
+			activate(el);
+			deactivateSoon(el);
+		}
+	}, true);
+
+	/* mouseenter/leave don't bubble; mouseover/out do, so delegate with closest(). */
+	$(document)
+		.on("mouseover.caBarActivity", function(e) {
+			var el = paneFrom(e.target);
+			if (el) activate(el);
+		})
+		.on("mouseout.caBarActivity", function(e) {
+			var el = paneFrom(e.target);
+			if (el) deactivateSoon(el);
+		});
+}
+
+/**
  * Register delegated `body`/`document` handlers for CA (cards, plugins, moderation, sorting, etc.).
  * Call once after DOM ready.
  */
 function caInitializeClickHandlers() {
-	/* Scrollbars: CA now uses the browser's native scrollbars on its
-	   scrollable panes, styled directly in the stylesheet. The former
-	   fixed-overlay scrollbar implementation was removed. */
+	/* Scrollbars: native browser bars, styled in the stylesheet. The only JS is
+	   caInitScrollbarActivity (below), which toggles .ca_bar_active so the bar
+	   can grow while a pane is hovered or scrolled. */
+	caInitScrollbarActivity();
 
 	if (window.caEnableLegacyExternalLinkGuard) {
 		/**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -873,20 +873,31 @@ body,
 	/* ==========================================================================
 	   Native scrollbars for CA's scrollable panes.
 
-	   Replaces the former fixed-overlay JS scrollbar (the .ca_fixed_* indicators
-	   and #ca_fixed_scroll_root, removed from clickHandlers.js). WebKit/Blink get
-	   px-precise sizing plus a rounded brand-orange thumb; Firefox gets the
-	   standard scrollbar-width / scrollbar-color styling (it cannot set an
-	   arbitrary px width or round the thumb, so it renders a thin orange bar).
+	   Always visible (not auto-hidden): a rounded brand-orange thumb that sits at
+	   ~2px normally and fills to ~5px on interaction. WebKit/Blink get the full
+	   treatment (px sizing, rounded thumb, hover grow); Firefox can only do a
+	   fixed thin bar with two colors and has no hover state, so it stays "thin"
+	   always — as close as Firefox allows.
 	   ========================================================================== */
-	.menuItems,
-	.sidenav,
-	.ca_homeTemplates,
-	.mainArea,
-	.ca_diffCol {
-		scrollbar-width: thin;
-		scrollbar-color: var(--brand-orange) transparent;
+	/* Firefox only. It has no ::-webkit-scrollbar, so give it a normal-width bar
+	   with an orange thumb and a transparent track. Gated behind @supports so
+	   Chrome 121+ (which now also understands scrollbar-width) does NOT pick this
+	   up — if it did, Chrome would ignore the ::-webkit-scrollbar rules below and
+	   revert to its auto-hiding overlay bar. Firefox has no hover state, so it
+	   just stays at normal width. */
+	@supports not selector(::-webkit-scrollbar) {
+		.menuItems,
+		.sidenav,
+		.ca_homeTemplates,
+		.mainArea,
+		.ca_diffCol {
+			scrollbar-width: auto;
+			scrollbar-color: var(--brand-orange) transparent;
+		}
 	}
+	/* Channel reserves the normal (hover/scrolling) bar width; the thumb is inset
+	   to ~2px at rest and fills the full width on interaction. An explicit width
+	   also forces an always-visible bar (overrides the macOS overlay auto-hide). */
 	.menuItems::-webkit-scrollbar,
 	.sidenav::-webkit-scrollbar,
 	.ca_homeTemplates::-webkit-scrollbar,
@@ -902,26 +913,36 @@ body,
 	.ca_diffCol::-webkit-scrollbar-track {
 		background: transparent;
 	}
+	/* Default ~2px rounded pill at half strength (calmer when idle): a transparent
+	   border + padding-box clip insets the visible thumb within the 10px channel. */
 	.menuItems::-webkit-scrollbar-thumb,
 	.sidenav::-webkit-scrollbar-thumb,
 	.ca_homeTemplates::-webkit-scrollbar-thumb,
 	.mainArea::-webkit-scrollbar-thumb,
 	.ca_diffCol::-webkit-scrollbar-thumb {
-		background-color: var(--brand-orange);
+		background-color: color-mix(in srgb, var(--brand-orange) 50%, transparent);
 		border-radius: 999px;
-		/* Transparent border + padding-box clip insets the thumb so it reads as a
-		   slim pill with breathing room (echoing the old overlay's thin thumb). */
-		border: 3px solid transparent;
+		border: 4px solid transparent;
 		background-clip: padding-box;
 	}
+	/* Grow to the full (normal) channel width while the pane is hovered or scrolled. WebKit
+	   won't restyle a scrollbar from the container's :hover state alone (it only
+	   repaints when the bar itself redraws), so caInitScrollbarActivity toggles
+	   .ca_bar_active on the pane via JS; a class change invalidates style
+	   thoroughly enough to repaint the bar on both enter and leave. The direct
+	   thumb:hover is kept as a no-JS fallback for grabbing the bar. */
+	.menuItems.ca_bar_active::-webkit-scrollbar-thumb,
+	.sidenav.ca_bar_active::-webkit-scrollbar-thumb,
+	.ca_homeTemplates.ca_bar_active::-webkit-scrollbar-thumb,
+	.mainArea.ca_bar_active::-webkit-scrollbar-thumb,
+	.ca_diffCol.ca_bar_active::-webkit-scrollbar-thumb,
 	.menuItems::-webkit-scrollbar-thumb:hover,
 	.sidenav::-webkit-scrollbar-thumb:hover,
 	.ca_homeTemplates::-webkit-scrollbar-thumb:hover,
 	.mainArea::-webkit-scrollbar-thumb:hover,
 	.ca_diffCol::-webkit-scrollbar-thumb:hover {
-		/* Fill the full track width on hover, approximating the overlay's
-		   thin-to-thick grow (WebKit cannot transition scrollbar metrics). */
 		border-width: 0;
+		background-color: var(--brand-orange);
 	}
 	.menuItems::-webkit-scrollbar-corner,
 	.sidenav::-webkit-scrollbar-corner,


### PR DESCRIPTION
Polish on top of the merged native-scrollbar switch (#91). Two files; no `Apps.page` changes.

## Changes

- **Always visible (Chrome).** `scrollbar-width` is now gated to Firefox via `@supports not selector(::-webkit-scrollbar)`. Chrome 121+ understands `scrollbar-width` and, when it's set, ignores the `::-webkit-scrollbar` styling and falls back to its auto-hiding overlay bar. Scoping it to Firefox keeps Chrome on the styled (non-overlay, always-visible) WebKit bar.
- **Slim idle → grow on interaction.** The thumb is a slim ~2px pill at half-strength colour when idle, and fills the normal channel width at full colour while the pane is hovered or scrolled.
- **Firefox.** `scrollbar-width: auto` (normal) with a transparent track. Firefox has no hover state, so it stays at normal width (closest it allows).
- **`caInitScrollbarActivity` shim (`clickHandlers.js`).** WebKit won't restyle a scrollbar from the container's `:hover` state alone (it only repaints the bar when the bar itself redraws), so a pure-CSS hover grow is unreliable on static panes. This toggles `.ca_bar_active` on a pane from hover + capture-phase scroll (so wheel/trackpad count), and an idle timeout returns it to slim. A class change invalidates style thoroughly enough that the bar repaints on enter and leave.

## Files
- `skins/Narrow/styles/community.applications.css` — scrollbar block only
- `javascript/clickHandlers.js` — the activity shim
- `plugins/CHANGES.md` — user-facing bullet

## Test plan
- Chrome (Mac): bars stay visible; idle slim/dim; hovering or scrolling any pane (apps grid, menu, sidebar, home rows) thickens its bar, then it slims back shortly after.
- Firefox: normal-width orange bar, transparent track.

> Independent of PR #92 (which carries the dropInfoCache + `.spotlightInfoArea` fixes); no file overlap with the next, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scrollbars in the app browser now act as persistent slim indicators and visibly thicken while hovering or during scrolling, improving discoverability and interaction feedback.

* **Style**
  * Updated cross-browser scrollbar visuals: default thumb is subtle and semi-transparent, becoming fully opaque and bolder on hover or when active for clearer focus and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->