### PR TITLE
fix: template text, restore-state, and UI fixes (button click target, 3-wide badges)

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,9 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Fixed: App descriptions and the "Additional Requirements" panel no longer show stray "br" or "&nbsp;" text from multi-line template fields, and render as clean lines
+- Fixed: After installing an app and returning to the browser, clicking a category now keeps you within your active search instead of dropping back to the whole category
+- Fixed: Returning from an install now restores the Home section heading (e.g. a "Show more" section title) instead of clearing it
 - Changed: The app browser's scrollbars now stay visible as a slim marker and thicken while you hover or scroll the area
 - Fixed: Installing an app from a template no longer briefly flashes an error (most noticeable in Firefox) — a background request was being cancelled as the page navigated and reported as a failure
 - Fixed: The spotlight app's info area now spans the full available width

--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,8 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Fixed: The action buttons (Install, Update, Uninstall, etc.) now respond to a click anywhere on the button, not just on the label text
+- Changed: App cards now fit up to three status badges on a row before wrapping (was two)
 - Fixed: App descriptions and the "Additional Requirements" panel no longer show stray "br" or "&nbsp;" text from multi-line template fields, and render as clean lines
 - Fixed: After installing an app and returning to the browser, clicking a category now keeps you within your active search instead of dropping back to the whole category
 - Fixed: Returning from an install now restores the Home section heading (e.g. a "Show more" section title) instead of clearing it

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -3258,6 +3258,10 @@ function saveState() {
 		state.installMulti  = $(".multi_installDiv").is(":visible");
 		state.selectedMenu  = $(".selectedMenu").data("category") || "";
 		state.categoryName  = $(".categoryMenuName").html() || "";
+		/* The Home section subtitle (the Show More section description) is not a
+		   search, so state.filter does not capture it. Save its text so a
+		   return-from-install restores it too. */
+		state.homeSectionSubtitle = $("#ca_homeSectionSubtitle").text() || "";
 		state.currentpage   = parseInt(data.currentpage, 10) || 1;
 		var _ma = $(".mainArea")[0];
 		state.scrollY       = _ma ? (_ma.scrollTop || 0) : 0;
@@ -3290,12 +3294,20 @@ function restoreState(s) {
 	$("#searchBox").val(s.filter || "");
 	data.committedSearchFilter = $.trim(s.filter || "");
 	data.searchActive = (s.filter || "") !== "";
+	/* Restore searchFlag too, not just searchActive. The category-menu click
+	   handler clears the search box and committed term unless data.searchFlag is
+	   set, so without this a category click after a restore drops back to the
+	   full category instead of subsetting the restored search. */
+	data.searchFlag = data.searchActive;
 	$(".categoryMenuName").html(s.categoryName || "");
 	restoreStateMenu = s.selectedMenu || "";
 	data.currentpage = parseInt(s.currentpage, 10) || 1;
 	data.maxPerPage = getMaxPerPage();
 	caSyncSearchFilterCollapsed();
 	caSyncHomeSearchSubtitle();
+	/* Restore the Home section subtitle (e.g. from a Show More) — empty text
+	   just hides it. */
+	if (typeof caSetHomeSectionSubtitle === "function") caSetHomeSectionSubtitle(s.homeSectionSubtitle || "");
 
 	post({action:"getSortOrder"}, function(sortOrder) {
 		$(".sortIcons").removeClass("enabledIcon");
@@ -5018,12 +5030,23 @@ function caRenderSidebarRequires() {
 		if (typeof raw !== "string" || raw === "") {
 			$section.text("");
 		} else {
-			/* Normalize newlines the way the old PHP path did before handing
-			   to markdown: drop \r and the &#xD; entity, turn \n into a
-			   markdown hard-break (two trailing spaces + newline). marked
-			   treats "  \n" as <br> regardless of the `breaks` option, which
-			   matches caSanitizeReadme's defaults. */
-			var normalized = raw.replace(/\r/g, "").replace(/&#xD;/g, "").replace(/\n/g, "  \n");
+			/* Normalize the feed/template multi-line encoding before handing to
+			   markdown. The feed stores breaks as <br> and indentation as &nbsp;
+			   runs; left in, caSanitizeReadme's stripTags drops the < > and leaves
+			   a literal "br", and marked escapes the &nbsp; into visible text. So:
+			   convert <br> to newlines, collapse &nbsp; to spaces, drop carriage
+			   returns (incl. the &#xD; the feed pads lines with), strip the
+			   structural leading indentation, then turn \n into a markdown
+			   hard-break (two trailing spaces + newline; marked treats "  \n" as a
+			   break regardless of the `breaks` option). Whitespace/break only — the
+			   result still goes through caSanitizeReadme (stripTags + marked +
+			   DOMPurify), so sanitization is unchanged. */
+			var normalized = raw
+				.replace(/<br\s*\/?>/gi, "\n")
+				.replace(/&nbsp;|&#160;|&#xA0;/gi, " ")
+				.replace(/&#xD;|&#13;|\r/gi, "")
+				.replace(/^[ \t]+/gm, "")
+				.replace(/\n/g, "  \n");
 			var html = caSanitizeReadme(normalized);
 			html = caApplySidebarSearchLinksJs(html);
 			$section.html(html);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -1151,14 +1151,33 @@ function versionCheck($template) {
 function removeXMLtags(&$template) {
 	foreach ($template as $key => &$element) {
 		if ( is_array($element) ) {
-				removeXMLtags($element);
+			removeXMLtags($element);
+			continue;
+		}
+
+		$value = (string)($element ?? "");
+
+		/* Normalize the multi line display encoding the feed bakes into text
+		   fields so it does not surface downstream as a literal br or nbsp:
+		   break tags become newlines, carriage returns (including the ones the
+		   feed pads line ends with) are dropped, the non breaking spaces it uses
+		   for indentation collapse to ordinary spaces, and per line leading
+		   indentation is removed. This only converts breaks and collapses
+		   whitespace. It never unescapes content or introduces markup, so the
+		   tag stripping below is unaffected and clean fields keep their
+		   existing entity escaping. */
+		$value = preg_replace('#<br\s*/?>#i', "\n", $value) ?? $value;
+		$value = str_replace(["\r", "&#xD;", "&#13;", "&#x0D;"], "", $value);
+		$value = str_replace(["&nbsp;", "&#160;", "&#xA0;"], " ", $value);
+		$value = preg_replace('/^[ \t]+/m', "", $value) ?? $value;
+
+		/* Existing tag strip pass, preserved: when decoding the value reveals
+		   real tags, remove their angle brackets so nothing can execute. */
+		$decoded = str_replace("<br>", "\n", htmlspecialchars_decode($value));
+		if ( trim($decoded) !== trim(strip_tags($decoded)) ) {
+			$element = str_replace(["<", ">"], ["", ""], $decoded);
 		} else {
-			$tempElement = htmlspecialchars_decode($element??"");
-			$tempElement = str_replace("<br>","\n",$tempElement);
-			if ( trim($tempElement) !== trim(strip_tags($tempElement)) ) {
-				$tempElement = str_replace(["<",">"],["",""],$tempElement);
-				$element = $tempElement;
-			}
+			$element = $value;
 		}
 	}
 }

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -86,6 +86,21 @@ function caInitializeClickHandlers() {
 	   can grow while a pane is hovered or scrolled. */
 	caInitScrollbarActivity();
 
+	/* Action buttons (.caButton) carry the action's onclick on their inner
+	   <span>, but the wrapper holds the padding and the icon — so clicks on the
+	   orange padding or the icon miss the handler and only the text itself fires
+	   (the "Install needs two clicks / only the word works" report). Forward a
+	   wrapper click to the span so the whole button is the hit target. The guard
+	   skips clicks that already landed on the span (or its contents) so the
+	   action fires exactly once, and buttons whose handler is elsewhere (no inner
+	   span[onclick]) are untouched. */
+	$("body").on("click", ".caButton", function(e) {
+		var span = $(this).children("span[onclick]")[0];
+		if (!span) return;
+		if (e.target === span || (span.contains && span.contains(e.target))) return;
+		span.click();
+	});
+
 	if (window.caEnableLegacyExternalLinkGuard) {
 		/**
 		 * Legacy external-link guard: intercept clicks on anchors, `.ca_href`,

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -56,6 +56,45 @@ function caApplySidebarSearchLinks($text) {
 }
 
 /**
+ * Normalize a multi-line feed text field before the overview / description
+ * renderers do their tag handling. Removes carriage returns (feed templates pad
+ * line ends with carriage-return entities, which decode to a stray CR that
+ * makes markdown emit a literal br) and strips the common leading indentation
+ * shared by every non-blank line (the template's structural XML indentation,
+ * which would otherwise render as runs of non-breaking spaces). Any deeper,
+ * intentional indentation on a line is preserved.
+ *
+ * Whitespace-only by design: it never adds, removes, or unescapes markup, so
+ * the caller's existing strip_tags and markdown sanitization runs on exactly
+ * the same content (minus CR / structural indent) and security is unchanged.
+ *
+ * @param string $text Field text, already passed through html_entity_decode().
+ * @return string
+ */
+function caNormalizeFeedText(string $text): string {
+	$text = str_replace("\r", "", $text);
+
+	$lines = explode("\n", $text);
+	$min = null;
+	foreach ($lines as $line) {
+		if (trim($line) === "") {
+			continue;
+		}
+		$indent = strlen($line) - strlen(ltrim($line, " \t"));
+		if ($min === null || $indent < $min) {
+			$min = $indent;
+		}
+	}
+	if ($min) {
+		foreach ($lines as $i => $line) {
+			$lines[$i] = (trim($line) === "") ? "" : substr($line, $min);
+		}
+		$text = implode("\n", $lines);
+	}
+	return $text;
+}
+
+/**
  * Build sanitized overview HTML for a template card (markdown, limited tags).
  *
  * @param array<string,mixed> $template
@@ -70,6 +109,7 @@ function caFormatOverview(array $template) {
 	}
 
 	$ovr = html_entity_decode($ovr);
+	$ovr = caNormalizeFeedText($ovr);
 	$ovr = str_replace(["[","]"],["<",">"],$ovr);
 	$ovr = str_replace("\n","<br>",$ovr);
 	$ovr = str_replace("    ","&nbsp;&nbsp;&nbsp;&nbsp;",$ovr);
@@ -1951,6 +1991,7 @@ function caNormalizeOverview(array $template, string $name): string {
 	}
 
 	$normalized = html_entity_decode($overview);
+	$normalized = caNormalizeFeedText($normalized);
 	$normalized = trim($normalized);
 	$normalized = str_replace(["[", "]"], ["<", ">"], $normalized);
 	$normalized = str_replace("\n", "<br>", $normalized);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -2453,13 +2453,14 @@ input[type="button"] {
 	   to a new row BELOW when more badges than fit in `max-width` accumulate
 	   (rather than letting them slide left over the card icon).
 
-	   `max-width: 20rem` on a 36rem card leaves ~16rem of icon-safe space on
-	   the left. Anything beyond that wraps. */
+	   `max-width: 28rem` on a 36rem card fits three badges on a row before the
+	   fourth wraps below; badges wrap (never slide over the icon), and a
+	   three-badge row's natural width still clears the card icon on the left. */
 	.cardFlagStack {
 		position: absolute;
 		top: 0.75rem;
 		right: 0.75rem;
-		max-width: 20rem;
+		max-width: 28rem;
 		display: flex;
 		flex-direction: row-reverse;
 		flex-wrap: wrap;


### PR DESCRIPTION
Five fixes across two areas, all in `Apps.page` / `helpers.php` / `skin_helpers.php`.

## Template / Requires text normalization

Multi-line template fields are stored with the feed's display encoding (`<br>` for breaks, `&nbsp;` runs for indentation, `&#xD;` padding). Left as-is, the sidebar's `stripTags` drops the `<`/`>` and leaves a literal `br`, and `&nbsp;` shows as escaped text — so descriptions and the **Additional Requirements** panel rendered garbled.

- **`removeXMLtags` (helpers.php)** — the per-field security pass on locally-read XML now normalizes the encoding (`<br>`→newline, drop CR/`&#xD;`, `&nbsp;`→space, strip structural indent) and **always commits** the result. Whitespace/break only — it never unescapes content or adds markup, the angle-bracket strip still neutralizes real tags, and clean fields keep their entity escaping. **Security is unchanged.**
- **`caNormalizeFeedText` (skin_helpers.php)** — same normalization in the server overview/description renderers (the feed itself isn't run through `removeXMLtags`, so render-side coverage is needed).
- **`caRenderSidebarRequires` (Apps.page)** — same normalization before `caSanitizeReadme`, so the Requires sidebar renders clean for both feed-browsed and installed containers.

> Note on installed containers: they're read via `readXmlFile()` → `removeXMLtags` + `addMissingVars`, i.e. the strict sanitizer (more than the trusted feed gets). So this also covers their descriptions/Requires.

## Restore-state fixes (`Apps.page`)

- **`searchFlag`** — `restoreState` restored `searchActive` but not `searchFlag`. After installing an app and returning, the category-menu handler's `!data.searchFlag` guard wiped the search, so a category click dropped to the whole category instead of subsetting the search. Now both restore.
- **Home section subtitle** — `saveState` didn't capture `#ca_homeSectionSubtitle` (it's not a search, so `state.filter` missed it). Now saved and restored, so returning from an install keeps the section heading (e.g. a "Show more" title).

## Test plan
- A template with multi-line Requires (e.g. LocalAI): the Additional Requirements panel renders as clean lines, no literal `br`/`&nbsp;`. (Feed templates need a feed reprocess to re-cache; the render-side fixes apply immediately.)
- Search → install an app → return → click a category: stays within the search.
- Home "Show more" → install → return: section heading is still shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App descriptions and "Additional Requirements" no longer show stray line-break or non-breaking-space artifacts.
  * Search/category filter state and the Home section heading are preserved when returning from an app install.

* **Style**
  * App cards now fit more status badges per row before wrapping.

* **New Features**
  * Action buttons respond to clicks anywhere on the button (not just the label).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->