### PR TITLE
chore: remove dead spotlight CSS after SVG switch

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -200,3 +200,4 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 - Fixed: In Docker Hub search, the "Apps" button now switches back to the app store and immediately searches for what's typed (it previously did nothing). Backspacing the term below the two-character minimum no longer bounces you back to Apps — you stay in Docker Hub search to enter a new term, and only leave via the "Apps" or "Clear Search" buttons
 - Added: A new "Autoplay videos" setting (on by default) to turn the muted, autoplaying video previews in the app sidebar on or off
 - Changed: The monthly spotlight artwork now renders as a crisp, scalable graphic on app cards and in the sidebar, and the sidebar spotlight uses a tidier two-column layout
+- Chore: Removed dead spotlight styling left behind after the switch to the scalable inline graphic

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -479,7 +479,7 @@ function caBuildSpotlightSprite() {
 	// Hidden sprite container. width/height 0 plus absolute keeps it out of
 	// layout while the symbol stays referenceable by use href=#ca-monthly-spotlight.
 	$sprite  = '<style>:root{--ca-spotlight-w:'.$w.';--ca-spotlight-h:'.$h.';}</style>';
-	$sprite .= '<svg id="caSpotlightSprite" class="caSvgSprite" aria-hidden="true" focusable="false" ';
+	$sprite .= '<svg id="caSpotlightSprite" aria-hidden="true" focusable="false" ';
 	$sprite .= 'style="position:absolute;width:0;height:0;overflow:hidden" ';
 	$sprite .= 'xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">';
 	$sprite .= '<symbol id="ca-monthly-spotlight" viewBox="'.$viewBox.'">'.$inner.'</symbol>';

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -3781,12 +3781,6 @@ input[type="button"] {
 		align-items: center;
 	}
 
-	.spotlightIcon {
-		height: 11rem;
-		margin-bottom: -3.5rem;
-		margin-left: -4rem;
-		/* margin-top: -3rem; */
-	}
 	.spotlightIconArea .spotlightIcon {
 		/* Sidebar icon: set height, width follows the symbol aspect via the
 		   --ca-spotlight-* vars shipped in the sprite cache (see


### PR DESCRIPTION
Follow-up cleanup to #96. After the monthly spotlight moved to a scalable inline SVG `<symbol>`, two unreferenced leftovers remained.

## Removed
- **Base `.spotlightIcon` CSS rule** — fully shadowed by the scoped `.homespotlightIconArea .spotlightIcon` and `.spotlightIconArea .spotlightIcon` rules (each overrides height + margins, and every `.spotlightIcon` element lives in one of those containers), so its declarations never applied. No visual change.
- **`caSvgSprite` class** on the generated sprite `<svg>` — no CSS rule and no JS reference (the live-refresh path targets `.spotlight_svg_holder`). The `id="caSpotlightSprite"` is kept as an inspection handle.

## Intentionally NOT removed
- **`webImages/spotlight_{azure,black,gray,white}.png`** — although current code no longer references them, **legacy CA versions still fetch them from `master` via the old `SpotlightIcon-backup` URL**, so they must remain. (An earlier revision of this PR removed them; reverted.)

## Verification
- `php -l` clean.
- Base rule gone (`0`), both scoped rules intact (`2`), `caSvgSprite` no longer present.
- Native-scrollbar code audited while here — `caInitScrollbarActivity()`/`.ca_bar_active` and the `::-webkit-scrollbar` rules are all live; nothing orphaned.

No behavior change; pure dead-CSS removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Refactored spotlight icon styling in the sidebar to use scalable inline graphics, removing legacy styling rules and improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->