### PR TITLE
feat: move Settings/Credits into the search bar, add settings reset, rework sidebar UI

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -201,3 +201,9 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 - Added: A new "Autoplay videos" setting (on by default) to turn the muted, autoplaying video previews in the app sidebar on or off
 - Changed: The monthly spotlight artwork now renders as a crisp, scalable graphic on app cards and in the sidebar, and the sidebar spotlight uses a tidier two-column layout
 - Chore: Removed dead spotlight styling left behind after the switch to the scalable inline graphic
+- Changed: Settings and Credits now open from a gear and an info icon in the search bar instead of the menu, and the menu is trimmed to match
+- Changed: The Credits panel now shows the installed CA version and carries the Statistics, Change Log, and Help buttons; opening Statistics or Change Log from there shows a back arrow (and outside-click) that returns to Credits
+- Added: Settings panel reset controls — a Cancel button reverts pending changes, a Default button restores defaults, and a "Delete all setting files" option performs a complete factory reset (also clearing pinned apps and favourite repositories). Settings still save when you close the sidebar, with a reminder shown while there are unsaved changes
+- Fixed: Clearing the search now also clears the autocomplete suggestion chips
+- Changed: Polished the search bar, sidebar, and mobile layout — toolbar controls render as plain icons, and the status line moves into the page footer
+- Chore: Removed the "marked" library from the Credits list (it ships with the OS rather than being bundled by Community Applications)

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -255,10 +255,13 @@ function tr($string,$ret=false) {
      so we get the markdown renderer free. Used by caLoadSidebarReadmeSections
      to render README.md client-side instead of going through PHP. -->
 <script src='<?autov("/plugins/dynamix.docker.manager/javascript/markdown.js");?>'></script>
+<? if ( $responsiveOS ): ?>
 <!-- SmoothieCharts ships with dynamix (see DashStats.page) — used here for the
      sidebar's live CPU stream so we get true streaming-style rendering with
-     a fixed window instead of a frame-by-frame Chart.js redraw. -->
+     a fixed window instead of a frame-by-frame Chart.js redraw. Only needed on
+     7.2+ where the live usage graphs render, so only load it there. -->
 <script src='<?autov("/webGui/javascript/smoothie.js");?>'></script>
+<? endif; ?>
 
 <?php /* Settings-difference flags. Class list is `ca_KEY` (one entry per
          default.cfg key) for every key whose runtime value in
@@ -865,13 +868,11 @@ $(function(){
 			name:"Community Applications",
 			debug:false,
 			priority:true
-		},function(result) {
-			try {
-				var result = JSON.parse(result);
-				$("#caInstalledVersion").html(result.installedVersion);
-			} catch(e) {
-				$("#caInstalledVersion").html("Unknown");
-			}
+		},function() {
+			/* Runs for the update-check side effect only. The CA version used to
+			   be written into the menu's #caInstalledVersion here, but the version
+			   now renders server-side at the top of the Credits panel, so there's
+			   nothing to display from the callback. */
 		}
 	);
 
@@ -936,34 +937,44 @@ $(function(){
 
 				stripWrap.appendChild(leftBtn);
 				stripWrap.appendChild(stripUl);   // move the live awesomplete ul
-				stripWrap.appendChild(rightBtn);
-				searchArea.appendChild(stripWrap);
+				/* Strip (left caret + results ul) goes in the left group, which
+				   grows; the ul scrolls inside it. The right caret goes at the
+				   START of the right group (leftmost, nearest the results, ahead
+				   of the info + gear buttons) so it sits in-flow right at the clip
+				   boundary - no fixed positioning or reserved gutter. The info and
+				   gear stay the last children (visually and in tab order). */
+				var caRowMain = searchArea.querySelector(".caSearchRowMain") || searchArea;
+				var caRowEnd  = searchArea.querySelector(".caSearchRowEnd");
+				caRowMain.appendChild(stripWrap);
+				if (caRowEnd) caRowEnd.insertBefore(rightBtn, caRowEnd.firstElementChild);
+				else searchArea.appendChild(rightBtn);
 
 				var scrollByStep = function(dir) {
 					var step = Math.max(60, Math.floor(stripUl.clientWidth * 0.7));
 					stripUl.scrollBy({ left: dir * step, behavior: "smooth" });
 				};
 				/* Awesomplete closes on the input losing focus / "outside"
-				   click. Carets live in .searchArea, outside the awesomplete
-				   wrapper — so a normal click would steal focus from the
-				   input and Awesomplete would close before the scroll even
-				   happens. preventDefault on mousedown keeps focus on the
-				   input; the click still fires. stopPropagation guards
-				   against any document-level "click outside the widget"
-				   listener Awesomplete may install. */
-				$(stripWrap).on("mousedown", ".caInlineCaret", function(e) {
+				   click. Both carets live outside the awesomplete wrapper (left
+				   in the strip, right in the right group) — so a normal click
+				   would steal focus from the input and Awesomplete would close
+				   before the scroll even happens. preventDefault on mousedown
+				   keeps focus on the input; the click still fires. stopPropagation
+				   guards against any document-level "click outside the widget"
+				   listener Awesomplete may install. Bound directly to each caret
+				   element since they no longer share one container. */
+				$([leftBtn, rightBtn]).on("mousedown", function(e) {
 					e.preventDefault();
 					e.stopPropagation();
 				});
-				$(stripWrap).on("click", ".caInlineCaret", function(e) {
+				$([leftBtn, rightBtn]).on("click", function(e) {
 					e.stopPropagation();
 				});
-				$(stripWrap).on("click keydown", ".caInlineCaretLeft", function(e) {
+				$(leftBtn).on("click keydown", function(e) {
 					if (e.type === "keydown" && e.key !== "Enter" && e.key !== " ") return;
 					e.preventDefault();
 					scrollByStep(-1);
 				});
-				$(stripWrap).on("click keydown", ".caInlineCaretRight", function(e) {
+				$(rightBtn).on("click keydown", function(e) {
 					if (e.type === "keydown" && e.key !== "Enter" && e.key !== " ") return;
 					e.preventDefault();
 					scrollByStep(1);
@@ -971,9 +982,9 @@ $(function(){
 
 				/* Scroll-position-aware caret fade — see CSS for
 				   .caInlineCaretsAtStart on the wrap (left caret) and
-				   .caInlineCaretsAtEnd on the right caret itself (it's
-				   position:fixed outside the wrap so the wrap's class
-				   wouldn't reach it). */
+				   .caInlineCaretsAtEnd on the right caret itself (it lives in
+				   the right group, not the wrap, so the wrap's class wouldn't
+				   reach it). */
 				var updateCaretState = function() {
 					var atStart = stripUl.scrollLeft <= 1;
 					var atEnd   = (stripUl.scrollLeft + stripUl.clientWidth) >= (stripUl.scrollWidth - 1);
@@ -1999,6 +2010,18 @@ function clearSearchBox() {
 	data.searchActive = false;
 	data.searchFlag = false;
 	data.docker = "";
+	/* Close the autocomplete suggestion strip as part of clearing the search.
+	   searchActive / searchFlag are already false and the inputs are blank by
+	   here, so the #caInlineSearchBox awesomplete-close re-open guard stays quiet
+	   and the strip does not pop back open. Without this, clearing via the X or
+	   the Clear Search menu item left the suggestion chips on screen unless the
+	   search had been started from Home (that path unwinds through appStore). */
+	if (typeof inlineSearchAwesomplete !== "undefined" && inlineSearchAwesomplete) {
+		try { inlineSearchAwesomplete.close(); } catch (e) { /* no-op */ }
+	}
+	if (typeof searchBoxAwesomplete !== "undefined" && searchBoxAwesomplete) {
+		try { searchBoxAwesomplete.close(); } catch (e) { /* no-op */ }
+	}
 	caSyncSearchFilterCollapsed();
 	caSyncHomeSearchSubtitle();
 	if (typeof caSyncHomeMenuLabel === "function") caSyncHomeMenuLabel();
@@ -2020,6 +2043,9 @@ function clearSearchBox() {
    name `cookie` is kept as an alias because external callers (helpers.js, the
    install/update paths) still use it positionally. */
 function closeSidebar(keepIdentity=false,visible=false) {
+	/* Sidebar is closing - leave the Credits view-stack so a later app-back
+	   doesn't get routed to Credits. */
+	window.caSidebarBackTarget = "";
 	/* Always tear down the live-CPU poll loop on sidebar close — even when
 	   keepIdentity is true (gallery transitions etc.), because the gallery's
 	   afterClose path reopens the sidebar with a fresh popUpChart() call that
@@ -3353,6 +3379,10 @@ function restoreState(s) {
  * Open the Credits panel in the alternate (sidenav) view via jQuery helper.
  */
 function showCredits() {
+	/* Credits is the root of this little view stack, so clear the back target -
+	   no back arrow here, and outside-click closes (handled in the overlay
+	   click via .popUpBack being hidden). */
+	window.caSidebarBackTarget = "";
 	$("#caCredits").showAlternateView();
 }
 
@@ -3438,6 +3468,10 @@ function caChangeLog() {
 	post({action:'caChangeLog'},function(result) {
 		$(".caChanges").html(result.changelog);
 		$("#caChangeLog").showAlternateView();
+		/* Opened from Credits? showAlternateView hides .popUpBack by default;
+		   bring it back so there's a top-left arrow to Credits (the handler in
+		   clickHandlers.js routes it there when caSidebarBackTarget is credits). */
+		if (window.caSidebarBackTarget === "credits") $(".popUpBack").removeClass("ca_hide");
 	});
 }
 
@@ -4711,6 +4745,9 @@ function caSyncSidenavBottomPadding() {
  * @param {string} appname Human-readable application name
  */
 function showSidebarApp(apppath,appname) {
+	/* Opening an app popup leaves the Credits view-stack, so its top-left back
+	   arrow goes back to the app (default), not Credits. */
+	window.caSidebarBackTarget = "";
 	mySpinner();
 	disableSearch();
 	$.cookie("sidebarAppPath",apppath,{path:"/;SameSite=Lax"});

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -1144,6 +1144,18 @@ function clearTempForReload() {
  * @return void
  */
 function saveSettings() {
+	/* Complete factory reset (the Settings panel "Delete all setting files"
+	   toggle): drop the saved settings cfg plus the pinned apps, the accepted-
+	   warning marker, and the admin marker, and skip writing the toggles. The
+	   page reload that follows then comes up on stock defaults. */
+	if ( getPost("caFactoryReset", "") === "1" ) {
+		@unlink(CA_PATHS['pluginSettings']);
+		@unlink(CA_PATHS['pinnedV2']);
+		@unlink(CA_PATHS['warningAccepted']);
+		@unlink(CA_PATHS['caAdmin']);
+		postReturn(["ok" => true]);
+		return;
+	}
 	$cfg     = @parse_ini_file(CA_PATHS['pluginSettings']) ?: [];
 	$allowed = ["yes", "no", "true", "false"];
 	/* Explicit allowlist of the switches in the Settings panel

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -44,9 +44,12 @@ function caSettingSwitchInputs(string $name, array $caDefaults): string {
 	$off     = $isBool ? "false" : "no";
 	$live    = (string)($GLOBALS['caSettings'][$name] ?? $default);
 	$checked = ($live === $on) ? " checked" : "";
+	// data-default-on lets the settings panel Default button restore each switch
+	// to its default.cfg value client-side without another round trip.
+	$defaultOn = ($default === $on) ? "1" : "0";
 	$safeName = htmlspecialchars($name, ENT_QUOTES);
 	return "<input type='hidden' name='{$safeName}' value='{$off}'>"
-		. "<input type='checkbox' class='switch caSettingSwitch' name='{$safeName}' value='{$on}'{$checked}>";
+		. "<input type='checkbox' class='switch caSettingSwitch' name='{$safeName}' value='{$on}' data-default-on='{$defaultOn}'{$checked}>";
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -430,7 +430,6 @@ function caInitializeClickHandlers() {
 			doSearch(false);
 		}
 	});
-	$(".caChangeLog").on("click", function() { disableSort(); scrollToTop(); caChangeLog(); });
 	$(".mainArea").on("click", ".ca_multiselect", function() { enableMultiInstall(); });
 	/* body-delegated rather than #sidenavContent-delegated because the pin
 	   button gets relocated into .popupCloseAreaButtons (sibling of
@@ -593,14 +592,44 @@ function caInitializeClickHandlers() {
 		   while it's selected is still a no-op. */
 		if ($(this).hasClass("selectedMenu") &&
 		    (!$(".caRepositoryMenu").hasClass("selectedMenu") || $(this).hasClass("caRepositoryMenu"))) return;
-		if ($(this).hasClass("showStatistics")) { e.stopPropagation(); showStatistics(); }
-		else if ($(this).hasClass("showSettings")) { e.stopPropagation(); showSettings(); }
-		else if ($(this).hasClass("showCredits")) { e.stopPropagation(); showCredits(); }
 		/* Parent of a sub-menu: clicking it only expands the subs (no fetch),
 		   so on mobile we keep the menu open until the user actually picks
 		   one — the auto "All" entry or a real sub. */
-		else if ($(this).next(".subCategory").length) { /* leave menu open */ }
+		if ($(this).next(".subCategory").length) { /* leave menu open */ }
 		else { scrollToTop(); closeMenu(); }
+	});
+	/**
+	 * Settings gear (far right of the search area) opens the settings panel.
+	 * Delegated on body because the search area is relocated on some themes.
+	 * It is a role=button, so Enter and Space activate it as well as a click.
+	 */
+	$("body").on("click", ".caSettingsGear", function(e) {
+		e.stopPropagation();
+		showSettings();
+	});
+	$("body").on("keydown", ".caSettingsGear", function(e) {
+		if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+			e.preventDefault();
+			e.stopPropagation();
+			showSettings();
+		}
+	});
+	/**
+	 * Info button (search row, left of the gear) opens the Credits panel. The
+	 * Credits panel itself carries Statistics and Change Log buttons at the top
+	 * that open those panels. All are role=button (Enter / Space activate too) and
+	 * body-delegated, so the handlers also reach the Credits buttons after the
+	 * panel is cloned into the live sidebar.
+	 */
+	$("body").on("click keydown", ".caCreditsInfo, .caCreditsStatistics, .caCreditsChangeLog", function(e) {
+		if (e.type === "keydown" && e.key !== "Enter" && e.key !== " " && e.key !== "Spacebar") return;
+		e.preventDefault();
+		e.stopPropagation();
+		if ($(this).hasClass("caCreditsInfo")) showCredits();
+		/* Mark the origin so Statistics / Change Log show a back arrow to Credits
+		   (and outside-click returns there). showCredits clears it again. */
+		else if ($(this).hasClass("caCreditsStatistics")) { window.caSidebarBackTarget = "credits"; showStatistics(); }
+		else if ($(this).hasClass("caCreditsChangeLog")) { window.caSidebarBackTarget = "credits"; caChangeLog(); }
 	});
 	/**
 	 * Category-menu click: clear the search box (when no in-progress search),
@@ -639,7 +668,12 @@ function caInitializeClickHandlers() {
 		$(".caChart").hide();
 		$("#" + $(this).data("chart")).show();
 	});
-	$(".sidebar").on("click", ".popUpBack", function() { showSidebarApp($.cookie("sidebarAppPath"), $.cookie("sidebarAppName")); });
+	$(".sidebar").on("click", ".popUpBack", function() {
+		/* Statistics / Change Log opened from Credits route back to Credits;
+		   every other sidebar's back arrow returns to the app popup. */
+		if (window.caSidebarBackTarget === "credits") { showCredits(); return; }
+		showSidebarApp($.cookie("sidebarAppPath"), $.cookie("sidebarAppName"));
+	});
 	/**
 	 * Menu-selection state: highlight the clicked `.caMenuItem` as
 	 * `selectedMenu`, slide-open its sub-menu, and collapse siblings when
@@ -1631,7 +1665,10 @@ function caBindSettingsFormHandlers(initialFormState) {
 	   "no" fallback alongside it — disabled fields are excluded from
 	   form serialization, and we want the hidden "no" to still submit
 	   so /update.php always writes a clean value for this key. */
-	if (!$("html").hasClass("Theme--responsive")) {
+	/* Re-appliable so the factory-reset toggle below can restore these locks
+	   after it temporarily disables every switch. */
+	function caApplyLegacyDisables() {
+		if ($("html").hasClass("Theme--responsive")) return;
 		$form.find(".caUseWholeDisplayWindowCard")
 			.addClass("ca_settingDisabled")
 			.find("input[type='checkbox'][name='useWholeDisplayWindow']")
@@ -1644,10 +1681,55 @@ function caBindSettingsFormHandlers(initialFormState) {
 			.find("input[type='checkbox'][name='displayUsageGraphs']")
 				.prop("disabled", true);
 	}
+	caApplyLegacyDisables();
 
 	/* Stash the initial serialized state on the form so closeSidebar() can
 	   detect dirty fields and auto-submit when the panel is dismissed. */
 	$form.data("caInitialState", initialFormState);
+
+	/* Cancel / Default / factory-reset controls. Bound delegated on the
+	   persistent #sidenavContent (off/on so re-opening doesn't stack them).
+	   Nothing here saves - the existing dirty-on-close submit handles that. */
+	/* The Cancel / Default controls are <div role=button> (caButton), so their
+	   disabled state is the .ca_disabled class, not the disabled property. The
+	   real <input> switches still use prop("disabled"). */
+	$sidenav.off("change.caSettingsDirty", "input.caSettingSwitch")
+		.on("change.caSettingsDirty", "input.caSettingSwitch", function() {
+			$sidenav.find(".caSettingsCancel").removeClass("ca_disabled");
+		});
+	/* Cancel: restore every switch to the user's saved (server-rendered) state
+	   via defaultChecked, drop the factory-reset row, re-enable everything. */
+	$sidenav.off("click.caSettingsCancel", ".caSettingsCancel")
+		.on("click.caSettingsCancel", ".caSettingsCancel", function() {
+			if ($(this).hasClass("ca_disabled")) return;
+			$form.find("input.caSettingSwitch").each(function() { this.checked = this.defaultChecked; });
+			$form.find(".caFactoryReset").prop("checked", false);
+			$form.find("input.caSettingSwitch").prop("disabled", false);
+			$form.find(".ca_settingCard").not(".caFactoryResetCard").removeClass("ca_settingDisabled");
+			$sidenav.find(".caSettingsDefault").removeClass("ca_disabled");
+			caApplyLegacyDisables();
+			$(this).addClass("ca_disabled");
+		});
+	/* Default: set every switch to its default.cfg value (data-default-on) and
+	   reveal the factory-reset row. Counts as a change, so Cancel turns on. */
+	$sidenav.off("click.caSettingsDefault", ".caSettingsDefault")
+		.on("click.caSettingsDefault", ".caSettingsDefault", function() {
+			if ($(this).hasClass("ca_disabled")) return;
+			$form.find("input.caSettingSwitch").each(function() {
+				this.checked = ($(this).attr("data-default-on") === "1");
+			});
+			$sidenav.find(".caSettingsCancel").removeClass("ca_disabled");
+		});
+	/* Factory reset: while checked, lock out every other setting option. */
+	$sidenav.off("change.caFactoryReset", ".caFactoryReset")
+		.on("change.caFactoryReset", ".caFactoryReset", function() {
+			var on = this.checked;
+			$sidenav.find(".caSettingsCancel").removeClass("ca_disabled");
+			$form.find("input.caSettingSwitch").prop("disabled", on);
+			$form.find(".ca_settingCard").not(".caFactoryResetCard").toggleClass("ca_settingDisabled", on);
+			$sidenav.find(".caSettingsDefault").toggleClass("ca_disabled", on);
+			if (!on) caApplyLegacyDisables();
+		});
 
 	/**
 	 * Submit handler for `.ca_settingsForm`: guard against re-entry, show a
@@ -1672,6 +1754,10 @@ function caBindSettingsFormHandlers(initialFormState) {
 		/* Collect each toggle's effective value — the checkbox's value when
 		   checked, otherwise its paired hidden ("off") input — and persist them. */
 		var settings = { action: "saveSettings" };
+		/* Factory reset: tell saveSettings to delete the cfg + pinned / accepted /
+		   admin files instead of writing the toggles. The page reload that follows
+		   then comes up on stock defaults. */
+		if ($localForm.find(".caFactoryReset").is(":checked")) settings.caFactoryReset = "1";
 		$localForm.find("input.caSettingSwitch").each(function() {
 			if (!this.name) return;
 			settings[this.name] = this.checked

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -1702,6 +1702,10 @@ function caBindSettingsFormHandlers(initialFormState) {
 	$sidenav.off("click.caSettingsCancel", ".caSettingsCancel")
 		.on("click.caSettingsCancel", ".caSettingsCancel", function() {
 			if ($(this).hasClass("ca_disabled")) return;
+			/* Setting .checked / .prop("checked") programmatically does NOT fire a
+			   change event, so the change.caSettingsDirty handler below stays quiet
+			   during this reset - the final addClass("ca_disabled") is not racing
+			   any removeClass and the form ends up clean + Cancel disabled. */
 			$form.find("input.caSettingSwitch").each(function() { this.checked = this.defaultChecked; });
 			$form.find(".caFactoryReset").prop("checked", false);
 			$form.find("input.caSettingSwitch").prop("disabled", false);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/statistics.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/statistics.js
@@ -562,6 +562,10 @@ function showStatistics() {
 		}
 
 		$content.showAlternateView();
+		/* Opened from Credits? showAlternateView hides .popUpBack by default;
+		   bring it back so there's a top-left arrow to Credits (the handler in
+		   clickHandlers.js routes it there when caSidebarBackTarget is credits). */
+		if (window.caSidebarBackTarget === "credits") $(".popUpBack").removeClass("ca_hide");
 
 		/* Feed SHA comparison is a separate, slower call (downloads both mirrors
 		   server-side), so fetch it after the view is up and patch the LIVE

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
@@ -25,17 +25,16 @@ $(function() {
 	// ever sourced from anything beyond the static set in skin.php.
 	$("html").addClass(<?= json_encode($htmlClasses, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>);
 
-	// Position the search area so it's sticky.  (Pre 7.2 sticky isn't supported on azure or gray themes)
-	<? if ( $responsiveOS || ($display['theme'] == 'black' || $display['theme'] == 'white') ):?>
-		$(".searchAreaHolder").insertAfter("#menu");
-	<? endif; ?>
-
-	// Move the sidebar to the body so it fills the entire screen.
-	$(".sidebar").appendTo("body");
-	// Status area sits just before the page footer spacer (falls back to body).
-	var $caFooterSpacer = $(".footer-spacer");
-	if ($caFooterSpacer.length) $(".ca_statusArea").insertBefore($caFooterSpacer.first());
-	else $(".ca_statusArea").appendTo("body");
+	// Status area moves into the page footer as the last child of .footer-left.
+	// Falls back to before the footer spacer, then body, if .footer-left is absent.
+	var $caFooterLeft = $(".footer-left");
+	if ($caFooterLeft.length) {
+		$(".ca_statusArea").appendTo($caFooterLeft.first());
+	} else {
+		var $caFooterSpacer = $(".footer-spacer");
+		if ($caFooterSpacer.length) $(".ca_statusArea").insertBefore($caFooterSpacer.first());
+		else $(".ca_statusArea").appendTo("body");
+	}
 
 	$("body,.content").addClass("menuAdjust");
 
@@ -52,6 +51,10 @@ $(function() {
 <!-- Search Area - This gets moved to body on responsive and black and white themes on legacy OS -->
 <div class="searchAreaHolder menuAdjust">
 	<div class='searchArea onlyShowWithFeed'>
+		<!-- Left group: search controls plus the JS-appended results strip (left
+		     caret + the scrolling ul). flex:1 and min-width:0 so the ul scrolls
+		     inside this group instead of pushing the right group off. -->
+		<div class='caSearchRowMain'>
 		<div class='mobileMenuButton'>
 			<div class='showMenuButton caButton menuAdjust menuHidden' title="<?tr("Show Menu");?>"></div>
 			<div class='closeMenuButton caButton menuAdjust menuHidden' title="<?tr("Close Menu");?>"></div>
@@ -97,6 +100,14 @@ $(function() {
 		<div class='dockerSearch caButton hideWithMenu ca_hide' title="<?tr("Search dockerHub for more containers");?>"><span class='caBtnLabel'><?tr("DockerHub");?></span></div>
 		<div class='templateSearch caButton hideWithMenu ca_hide' title="<?tr("Search for applications from");?>"><span class='caBtnLabel'><?tr("Apps");?></span></div>
 		<div class='ca_displayCount hideWithMenu' aria-live='polite'></div>
+		</div>
+		<!-- Right group: pinned to the right. The right scroll caret (injected by JS
+		     when results overflow, leftmost), the info button (opens Credits), and
+		     the settings gear live here, all in-flow. -->
+		<div class='caSearchRowEnd'>
+		<div class='caCreditsInfo hideWithMenu' role='button' tabindex='0' title="<?tr('Credits');?>" aria-label="<?tr('Credits');?>"><i class='fa fa-info-circle' aria-hidden='true'></i></div>
+		<div class='caSettingsGear hideWithMenu' role='button' tabindex='0' title="<?tr('Settings');?>" aria-label="<?tr('Settings');?>"><i class='fa fa-cog' aria-hidden='true'></i></div>
+		</div>
 	</div>
 </div>
 
@@ -214,19 +225,10 @@ $(function() {
 				<li class='categoryMenu caMenuItem caDuplicatesMenu onlyShowWithFeed nonDockerSearch' data-category='duplicates'><?tr("Duplicates");?></li>
 				<?endif;?>
 				<li><hr class='category_hr onlyShowWithFeed'/></li>
-				<li class='caMenuItem showSettings noSelect'><?tr("Settings");?></li>
-				<li class='caMenuItem showStatistics noSelect'><?tr("Statistics");?></li>
-				<li class='caMenuItem showCredits noSelect'><?tr("Credits");?></li>
-				<li class='caMenuItem noSelect'><a class='caMenuItem' href='https://forums.unraid.net/topic/38582-plug-in-community-applications/' target='_blank' rel='noopener noreferrer'><?tr("Support");?></a></li>
-				<li><hr class='category_hr'/></li>
-				<li><?=tr("VERSION");?></li>
-				<li><span id='caInstalledVersion'></span></li>
-				<li class='caMenuItem caChangeLog noSelect'><?tr("Change Log");?></li>
 				<?if ($md5Error):?>
 				<li><span class='modifiedCode'>Modified Code</span></li>
 				<br>
 				<?endif;?>
-				<li><hr/></li>
 				<li class='caMenuItem debugging noSelect'><?tr("Debugging");?></li>
 				<?if (($GLOBALS['caSettings']['dev'] ?? "no") == "yes"):?>
 				<li class='caMenuDisabled noSelect'><i class='fa fa-keyboard-o'></i>&nbsp;<i class='fa fa-arrow-up'></i>&nbsp;D</li>
@@ -247,6 +249,16 @@ $(function() {
 			<span class='popUpBack caButton' aria-label='<?tr("Back");?>' title='<?tr("Back");?>'></span>
 			<span class="popUpStat caButton" aria-label='<?tr("Back");?>' title='<?tr("Back");?>'></span>
 		</div>
+		<!-- Centered in the top bar, shown only while the Credits view is open
+		     (see body:has(#sidenavContent .credits) in the CSS). -->
+		<div class='caCreditsActions'>
+			<div class='caButton caCreditsStatistics' role='button' tabindex='0'><?tr("Stats");?></div>
+			<div class='caButton caCreditsChangeLog' role='button' tabindex='0'><?tr("Changes");?></div>
+			<a class='caButton caCreditsSupport' href='https://forums.unraid.net/topic/38582-plug-in-community-applications/' target='_blank' rel='noopener noreferrer'><?tr("Help");?></a>
+		</div>
+		<!-- Shown only while the settings panel is open AND Cancel is enabled
+		     (i.e. there are pending edits) - pure CSS via :has(), see below. -->
+		<div class='ca_settingsSaveNote'><?tr("Settings are saved when closing the sidebar.");?></div>
 	</div>
 	<!-- Mirror of popupCloseArea but at the BOTTOM of the viewport. The
 	     server keeps emitting .popupStickyActions inline with the popup
@@ -368,6 +380,7 @@ $(function() {
 	<!-- Credits view -->
 	<div id='caCredits'>
 		<div class='credits'>
+			<div class='ca_center ca_creditVersion'><?tr("VERSION");?> <?=htmlspecialchars((string)ca_plugin("version","/var/log/plugins/community.applications.plg"), ENT_QUOTES)?><?if ($md5Error):?> <span class='modifiedCode'>Modified Code</span><?endif;?></div>
 			<div class='ca_center caLogoIcon'></div>
 			<div class='ca_center ca_creditTitle'>Community Applications</div>
 			<div class='ca_center ca_creditheader'><?tr("Development");?></div>
@@ -388,7 +401,6 @@ $(function() {
 				<div>XML2Array/Array2XML (Miles Johnson) - Apache 2.0 licence - <?tr("Modified by Andrew Zawadzki");?></div>
 				<div>Magnific-Popup (Dmytro Semenov) - MIT licence - <?tr("Modified by Andrew Zawadzki");?></div>
 				<div>DOMPurify (Cure53 and other contributors) - Apache 2.0 / MPL 2.0 licence</div>
-				<div>marked (Christopher Jeffrey) - MIT licence</div>
 			</div>
 			<br>
 			<div class='ca_center ca_italic'><?tr("Copyright");?> &copy; 2020-2026 Lime Technology, 2015-2026 Andrew Zawadzki</div>
@@ -539,6 +551,11 @@ $(function() {
 			<form class='ca_settingsForm js-confirm-leave' method='POST' action='/update.php' target='progressFrame'>
 				<input type='hidden' name='#file' value='community.applications/community.applications.cfg'>
 
+				<div class='ca_settingsToolbar ca_center'>
+					<div class='caButton caSettingsCancel ca_disabled' role='button' tabindex='0'><?tr("Cancel");?></div>
+					<div class='caButton caSettingsDefault' role='button' tabindex='0'><?tr("Default");?></div>
+				</div>
+
 				<div class='ca_settingsGrid'>
 					<div class='ca_settingCard'>
 						<div class='ca_settingHeader'>
@@ -640,6 +657,13 @@ $(function() {
 							<?=caSettingSwitchInputs('dev', $caDefaults)?>
 						</div>
 						<div class='ca_settingDescription'><?tr("Unlock additional developer-focused features. Not generally recommended.");?></div>
+					</div>
+					<div class='ca_settingCard caFactoryResetCard'>
+						<div class='ca_settingHeader'>
+							<span><?tr("Delete all setting files");?></span>
+							<input type='checkbox' class='switch caFactoryReset' name='caFactoryReset' value='1'>
+						</div>
+						<div class='ca_settingDescription'><?tr("Complete factory reset. Also removes pinned apps and favourite repositories.");?></div>
 					</div>
 				</div>
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -1170,7 +1170,7 @@ body,
 	   AND the Cancel control is enabled (i.e. there are pending edits). The
 	   .caSettingsCancel:not(.ca_disabled) test covers both at once - that element
 	   only exists in the settings view, and loses .ca_disabled once dirty. */
-	@keyframes caSettingsNoteIn {
+	@keyframes ca-settings-note-in {
 		from { opacity: 0; transform: translate(-50%, calc(-50% - 0.3rem)); }
 		to   { opacity: 0.85; transform: translate(-50%, -50%); }
 	}
@@ -1189,7 +1189,7 @@ body,
 		font-style: italic;
 		opacity: 0.85;
 		z-index: 6;
-		animation: caSettingsNoteIn 220ms ease;
+		animation: ca-settings-note-in 220ms ease;
 	}
 
 	/* Cancel / Default action row at the top of the settings panel. */

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -88,7 +88,8 @@ body:has(.sidenavShow) {
 }
 .ca_back_to_top:hover,
 .ca_move_to_end:hover {
-	background: color-mix(in srgb, var(--text-color) 14%, transparent);
+	/* Just recolor the icon on hover - no button background. */
+	color: var(--brand-orange);
 }
 .ca_back_to_top {
 	right: 40px;
@@ -1072,7 +1073,7 @@ body,
 	.sidenav {
 		/* Layout */
 		position: fixed;
-		top: 4rem;
+		top: 5rem;
 		right: 0;
 		bottom: 1.6rem;
 		margin-bottom: 1rem;
@@ -1162,6 +1163,47 @@ body,
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(28rem, 1fr));
 		gap: 1.2rem;
+	}
+
+	/* "Settings are saved when closing the sidebar" note. It lives in the sidebar
+	   top bar (.popupCloseArea) and only shows while the settings panel is open
+	   AND the Cancel control is enabled (i.e. there are pending edits). The
+	   .caSettingsCancel:not(.ca_disabled) test covers both at once - that element
+	   only exists in the settings view, and loses .ca_disabled once dirty. */
+	@keyframes caSettingsNoteIn {
+		from { opacity: 0; transform: translate(-50%, calc(-50% - 0.3rem)); }
+		to   { opacity: 0.85; transform: translate(-50%, -50%); }
+	}
+	.ca_settingsSaveNote {
+		display: none;
+	}
+	body:has(#sidenavContent .caSettingsCancel:not(.ca_disabled)) .ca_settingsSaveNote {
+		display: block;
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		max-width: 60%;
+		text-align: center;
+		color: var(--text-color);
+		font-style: italic;
+		opacity: 0.85;
+		z-index: 6;
+		animation: caSettingsNoteIn 220ms ease;
+	}
+
+	/* Cancel / Default action row at the top of the settings panel. */
+	.ca_settingsToolbar {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		gap: 0.75rem;
+		margin-bottom: 1.2rem;
+	}
+	.ca_settingsToolbar .caButton.ca_disabled {
+		opacity: 0.45;
+		cursor: default;
+		pointer-events: none;
 	}
 
 	.ca_settingCard {
@@ -1641,6 +1683,27 @@ body,
 		position: relative;
 		z-index: 1;
 	}
+	/* Statistics + Change Log buttons. They live in the sidebar top bar
+	   (.popupCloseArea) next to the close X, but only while the Credits view is
+	   open. Hidden by default; the body:has() rule below reveals them and centers
+	   the group in the bar (absolute, so it doesn't fight the right-anchored X). */
+	.caCreditsActions {
+		display: none;
+	}
+	body:has(#sidenavContent .credits) .caCreditsActions {
+		display: flex;
+		flex-direction: row;
+		gap: 0.75rem;
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		z-index: 6;
+	}
+	.ca_creditVersion {
+		margin-bottom: 0.75rem;
+		opacity: 0.85;
+	}
 	/* Dim FA glyph painted behind the sidenav credits view as a watermark.
 	   Lives on body::after rather than .sidenav::after because .sidenav has
 	   transform:translateX(...) for its slide animation, which creates a
@@ -1673,7 +1736,7 @@ body,
 		z-index: 1000;
 		transition: transform 500ms ease, opacity 500ms ease;
 	}
-	body:has(.sidenavShow :is(.credits, .caChanges))::after {
+	body:has(.sidenavShow :is(.credits, .caChanges, .ca_statistics, .moderationContainer))::after {
 		opacity: 0.1;
 		transform: translateX(0);
 	}
@@ -3236,7 +3299,7 @@ input[type="button"] {
 		flex: 0 1 auto;
 		min-width: 0;
 	}
-	.searchArea > .caInlineStripWrap {
+	.caSearchRowMain > .caInlineStripWrap {
 		flex: 1 1 auto;
 		min-width: 0;
 		display: flex;
@@ -3246,10 +3309,10 @@ input[type="button"] {
 	}
 	/* Collapse to nothing when the strip's ul is hidden (no suggestions
 	   to show), so the search row's other items get the freed space. */
-	.searchArea > .caInlineStripWrap:has(> ul[hidden]) {
+	.caSearchRowMain > .caInlineStripWrap:has(> ul[hidden]) {
 		display: none;
 	}
-	.searchArea > .caInlineStripWrap > ul {
+	.caSearchRowMain > .caInlineStripWrap > ul {
 		flex: 1 1 auto;
 		min-width: 0;
 		margin: 0;
@@ -3262,19 +3325,18 @@ input[type="button"] {
 		overflow-x: auto;
 		overflow-y: hidden;
 		white-space: nowrap;
-		background: color-mix(in srgb, var(--text-color) 8%, transparent);
 		border-radius: 0.6rem;
 		/* Hide the native scrollbar entirely; scrolling still works via
 		   trackpad gestures, shift+wheel, or the caret buttons. */
 		scrollbar-width: none;
 	}
-	.searchArea > .caInlineStripWrap > ul::-webkit-scrollbar {
+	.caSearchRowMain > .caInlineStripWrap > ul::-webkit-scrollbar {
 		display: none;
 	}
-	.searchArea > .caInlineStripWrap > ul[hidden] {
+	.caSearchRowMain > .caInlineStripWrap > ul[hidden] {
 		display: none !important;
 	}
-	.searchArea > .caInlineStripWrap > ul > li {
+	.caSearchRowMain > .caInlineStripWrap > ul > li {
 		flex: 0 0 auto;
 		margin: 0;
 		max-width: none;
@@ -3288,14 +3350,14 @@ input[type="button"] {
 	   which would promote a chip's "<text><mark>match</mark><text>" into
 	   three flex items and inject visible spaces around the highlight
 	   (the same bug the modal awesomplete chips hit). */
-	.searchArea > .caInlineStripWrap > ul > li.caButton {
+	.caSearchRowMain > .caInlineStripWrap > ul > li.caButton {
 		display: inline-block;
 		gap: 0;
 		font-size: 1.25rem;
 		padding: 0.4rem 0.9rem;
 		line-height: 1.25;
 	}
-	.searchArea > .caInlineStripWrap > ul > li mark {
+	.caSearchRowMain > .caInlineStripWrap > ul > li mark {
 		background: transparent;
 		color: var(--ca-suggestion-mark-color);
 	}
@@ -3321,23 +3383,22 @@ input[type="button"] {
 		background: color-mix(in srgb, var(--text-color) 22%, transparent);
 	}
 	/* Left caret stays in the flex flow at the start of the strip. */
-	.searchArea > .caInlineStripWrap > .caInlineCaretLeft {
+	.caSearchRowMain > .caInlineStripWrap > .caInlineCaretLeft {
 		flex: 0 0 auto;
 	}
-	/* Right caret floats at the viewport's right edge whenever an inline
-	   suggestion strip is open — no need for JS-computed width math. */
+	/* Right caret is an in-flow flex child of the right group (.caSearchRowEnd),
+	   sitting just left of the gear. It is hidden until an inline suggestion strip
+	   is open. No fixed positioning or reserved gutter - the left group clips the
+	   results at its edge and this caret sits right at that boundary. */
 	.caInlineCaretRight {
 		display: none;
-		position: fixed;
-		top: calc(var(--ca-header-image-height) + var(--ca-menu-height) + var(--search-area-top) + 0.4rem);
-		right: 1rem;
-		z-index: 7;
+		flex: 0 0 auto;
 	}
-	body:has(.searchArea > .caInlineStripWrap > ul:not([hidden])) .caInlineCaretRight {
+	body:has(.caSearchRowMain > .caInlineStripWrap > ul:not([hidden])) .caInlineCaretRight {
 		display: inline-flex;
 	}
 	/* Scroll-position-aware fade: left greys out at start, right at end. */
-	.searchArea > .caInlineStripWrap.caInlineCaretsAtStart > .caInlineCaretLeft {
+	.caSearchRowMain > .caInlineStripWrap.caInlineCaretsAtStart > .caInlineCaretLeft {
 		opacity: 0.2;
 		pointer-events: none;
 		cursor: default;
@@ -3355,7 +3416,7 @@ input[type="button"] {
 		right: 0;            /* span to viewport right so the inline strip can't push the row past the viewport */
 		position: fixed;
 		z-index: 6;
-		padding-right: 4.4rem; /* reserved gutter for the position:fixed .caInlineCaretRight */
+		padding-right: 0;
 	}
 	/* When the search modal is open, raise the holder's stacking context above
 	   the .ca_modal_overlay (z-index 999). Without this, the fixed #searchFilter
@@ -3373,6 +3434,42 @@ input[type="button"] {
 		justify-content: flex-start;
 		align-items: baseline;
 		gap: 0.5rem;
+	}
+	.caSearchRowMain {
+		/* Left group: grows to fill the row. min-width:0 lets the results ul
+		   shrink and scroll inside it (overflow-x:auto + hidden scrollbar) rather
+		   than pushing the right group off the edge. Keeps the row's baseline
+		   alignment for the text controls. */
+		flex: 1 1 auto;
+		min-width: 0;
+		display: flex;
+		flex-direction: row;
+		align-items: baseline;
+		gap: 0.5rem;
+	}
+	.caSearchRowEnd {
+		/* Right group: pinned to the right (the left group's flex:1 pushes it
+		   over). Holds the in-flow right scroll caret and the settings gear. */
+		flex: 0 0 auto;
+		display: flex;
+		flex-direction: row;
+		gap: 0.5rem;
+	}
+	.caSettingsGear,
+	.caCreditsInfo {
+		/* Search-row icon buttons (info + settings gear). They live in
+		   .caSearchRowEnd (the right group), already pushed to the right edge, so
+		   no margin or self-alignment is needed here. */
+		flex: 0 0 auto;
+		cursor: pointer;
+		padding: 0.25rem 0.5rem;
+		font-size: 1.7rem;
+		line-height: 1;
+		color: inherit;
+	}
+	.caSettingsGear:hover,
+	.caCreditsInfo:hover {
+		color: var(--brand-orange);
 	}
 	.Theme--width-boxed .searchAreaHolder {
 		max-width: 1920px;
@@ -3431,8 +3528,11 @@ input[type="button"] {
 		pointer-events: auto;
 	}
 	body:has(.mobileMenu.menuShowing) .ca_modal_overlay {
-	  left: 17rem;
-    }
+		left: 17rem;
+	}
+	body.Theme--sidebar:has(.mobileMenu.menuShowing) .ca_modal_overlay {
+		top: 0;
+	}
 	/* Pop the mobile menu above the scrim (default z-index 5 from responsive
 	   would put it under the z-index 999 overlay). Match the sidebar at 1000. */
 	body:has(.mobileMenu.menuShowing) .mobileMenu {
@@ -3733,7 +3833,25 @@ input[type="button"] {
 	.closeMenuButton {
 		left: 2rem;
 		top: 2rem;
-		margin-right: 1rem;
+		margin-right: 0;
+	}
+	/* Render the mobile menu toggles and the standalone search launcher as plain
+	   icons like .caSettingsGear / .caCreditsInfo: same 1.7rem size, drop the
+	   .caButton pill background, tight padding so they sit close together, and
+	   recolor to brand-orange on hover instead of a hover fill. */
+	.showMenuButton,
+	.closeMenuButton,
+	.searchButton {
+		background: transparent;
+		border-radius: 0;
+		padding: 0.25rem 0.5rem;
+		font-size: 1.7rem;
+	}
+	.showMenuButton:hover,
+	.closeMenuButton:hover,
+	.searchButton:hover {
+		background: transparent;
+		color: var(--brand-orange);
 	}
 
 	#sortIconArea {

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.overrides.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.overrides.css
@@ -47,6 +47,12 @@ body.Theme--sidebar:has(.multi_installDiv:not(.ca_hide):not([style*="display: no
 	bottom: 9rem;
 }
 
+/* Base stacking for the sidebar-layout menu. The modal-open states below are
+   more specific and bump it to the scrim plane (999) when needed. */
+.Theme--sidebar #menu {
+	z-index: 5;
+}
+
 /* In sidebar layouts the persistent #menu IS the OS sidebar — keep it
    parked at the modal-scrim plane (999) when a modal is open so it stays
    visible/interactive at scrim level instead of getting pushed below

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
@@ -210,6 +210,23 @@ body:has(.ca_useWholeDisplayWindow) {
 	#sortByButton::before {
 		margin-right: 0;
 	}
+	/* Icon-only now (labels hidden above) - render them as plain icons like the
+	   menu / search / gear controls: no .caButton pill, same 1.7rem size, tight
+	   padding, brand-orange on hover instead of a hover fill. */
+	.dockerSearch,
+	.templateSearch,
+	#sortByButton {
+		background: transparent;
+		border-radius: 0;
+		padding: 0.25rem 0.5rem;
+		font-size: 1.7rem;
+	}
+	.dockerSearch:hover,
+	.templateSearch:hover,
+	#sortByButton:hover {
+		background: transparent;
+		color: var(--brand-orange);
+	}
 
 	/* "Displaying x of N results" — drop on narrow viewports where the
 	   top-bar real estate is tight and the count isn't worth the row. */
@@ -264,6 +281,11 @@ body:has(.ca_useWholeDisplayWindow) {
 		bottom: 0;
 		margin-bottom: 0;
 	}
+	/* No footer to clear here either, so the popup action bar sits flush at the
+	   bottom (the base rule reserves 2.5rem for the footer). */
+	body:has(.sidenavShow) .popupActionsArea {
+		bottom: 0;
+	}
 	#header {
 		display: none;
 	}
@@ -274,7 +296,12 @@ body:has(.ca_useWholeDisplayWindow) {
 	.Theme--sidebar .searchAreaHolder {
 		background-color: var(--background-color);
 		width: 15rem;
-		margin-top: -1rem;
+		/* margin-top: -1rem; */
+		padding-bottom: 0.75rem;
+	}
+	/* Only pull the search bar flush-left while the menu is showing. */
+	.Theme--sidebar .searchAreaHolder.menuShowing {
+		left: 0;
 	}
 	/* Nav-top: narrow the search bar to make room for the open menu strip. */
 	.Theme--nav-top .searchAreaHolder.menuShowing {
@@ -327,6 +354,7 @@ body:has(.ca_useWholeDisplayWindow) {
 	.Theme--sidebar .menuItems {
 		/* `top` removed — shared calc in main CSS handles it. */
 		bottom: 0;
+		left: 0px;
 	}
 
 	/* `.Theme--sidebar .ca_display_area` top removed — shared calc in

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
@@ -296,7 +296,6 @@ body:has(.ca_useWholeDisplayWindow) {
 	.Theme--sidebar .searchAreaHolder {
 		background-color: var(--background-color);
 		width: 15rem;
-		/* margin-top: -1rem; */
 		padding-bottom: 0.75rem;
 	}
 	/* Only pull the search bar flush-left while the menu is showing. */


### PR DESCRIPTION
A batch of UI/UX work building on the spotlight changes (#96/#97).

## Search bar
- Refactored `.searchArea` into two flex groups — a growing left group whose results strip self-clips (and scrolls with a hidden scrollbar), and a right group holding the in-flow scroll caret, the **info** icon, and the **settings gear**. This retires the old `position: fixed` right caret + reserved-gutter + JS-computed-position hacks.
- Toolbar controls (menu toggle, search, DockerHub/Apps/sort in icon-only mode) now render as plain icons with an orange hover instead of pill buttons.

## Menu → Credits / search bar
- **Settings** (gear) and **Credits** (info) now open from icons in the search bar; removed Settings, Statistics, Credits, Change Log, Support and the VERSION block from the menu.
- The **Credits** panel now shows the installed CA version (server-side via `ca_plugin`) and hosts **Stats / Changes / Help** buttons in the top bar. Opening Stats or Change Log from Credits shows a top-left back arrow (and routes outside-click) back to Credits, via a small `caSidebarBackTarget` flag.
- Dropped `marked` from the Credits libraries list (ships with the OS, not bundled by CA).

## Settings panel reset
- **Cancel** (enabled once dirty) reverts every switch to the saved state (`defaultChecked`).
- **Default** sets every switch to its `default.cfg` value (new `data-default-on` attribute from `caSettingSwitchInputs`).
- A persistent **"Delete all setting files"** card: while checked it disables every other option; on close, the existing dirty-submit sends `caFactoryReset=1` and `saveSettings` deletes the cfg + pinned + accepted + admin files instead of writing (the reload then comes up on stock defaults).
- A top-bar **"Settings are saved when closing the sidebar"** note, shown purely via CSS `:has(#sidenavContent .caSettingsCancel:not(.ca_disabled))` while there are pending edits.

## Misc
- Clearing the search now also closes the autocomplete suggestion strip (was only closing on the from-Home path).
- `smoothie.js` only loads on 7.2+ (`$responsiveOS`).
- The status line moves into the page footer (`.footer-left`); the logo backdrop watermark now also shows on Statistics/Moderation; assorted sidebar-theme + mobile CSS polish.

## Notes for reviewers
- `paths.php` is intentionally **not** in this PR — the only SMB/master difference there is a stray whitespace re-alignment, not a real change.
- No `.plg` / `ca.md5` touched. CHANGES.md updated.
- New `tr()` strings ("Cancel", "Default", "Delete all setting files", "Stats", "Changes", "Help", etc.) render as-is until translated.

## Verification
- `php -l` clean on all `.php`/`.page`/`.html`; `node --check` clean on both JS files.
- Interaction-heavy (sidebar flows), so worth a manual pass on a live server: search-row caret/clip + clear, Settings reset/cancel/default/factory-reset, Credits → Stats/Changes back behaviour, and the mobile (<=767px) layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings and Credits now accessible via icons in the search bar
  * Credits panel shows installed plugin version and provides navigation back to Statistics/Change Log
  * Added Settings controls: Cancel, Default, and a factory-reset option (delete all setting files)

* **Bug Fixes**
  * Clearing search now also clears autocomplete suggestion chips and closes inline/modal suggestions
  * Sidebar back navigation now returns to Credits when appropriate

* **Style**
  * Toolbar controls redesigned as plain icons; search/sidebar visuals and footer/status positioning polished

* **Documentation**
  * Removed obsolete library attribution from Credits list
<!-- end of auto-generated comment: release notes by coderabbit.ai -->