### PR TITLE
feat: full-width sidebar-theme mobile layout and in-body credits actions

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -207,3 +207,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 - Fixed: Clearing the search now also clears the autocomplete suggestion chips
 - Changed: Polished the search bar, sidebar, and mobile layout — toolbar controls render as plain icons, and the status line moves into the page footer
 - Chore: Removed the "marked" library from the Credits list (it ships with the OS rather than being bundled by Community Applications)
+- Changed: On phones, the sidebar-style themes now use the full width for the app list and search bar and tuck the side menu away until you open it; the settings and credits icons stay pinned to the top-right
+- Changed: On narrow screens, the Credits panel's Statistics, Change Log, and Help buttons now appear at the top of the Credits page, where there's no room for them beside the close button
+- Fixed: Corrected a spacing glitch in the pop-out search bar
+- Chore: Removed some dead, commented-out styling left behind by earlier search-bar work

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
@@ -252,8 +252,8 @@ $(function() {
 		<!-- Centered in the top bar, shown only while the Credits view is open
 		     (see body:has(#sidenavContent .credits) in the CSS). -->
 		<div class='caCreditsActions'>
-			<div class='caButton caCreditsStatistics' role='button' tabindex='0'><?tr("Stats");?></div>
-			<div class='caButton caCreditsChangeLog' role='button' tabindex='0'><?tr("Changes");?></div>
+			<div class='caButton caCreditsStatistics' role='button' tabindex='0'><?tr("Statistics");?></div>
+			<div class='caButton caCreditsChangeLog' role='button' tabindex='0'><?tr("Change Log");?></div>
 			<a class='caButton caCreditsSupport' href='https://forums.unraid.net/topic/38582-plug-in-community-applications/' target='_blank' rel='noopener noreferrer'><?tr("Help");?></a>
 		</div>
 		<!-- Shown only while the settings panel is open AND Cancel is enabled
@@ -380,6 +380,14 @@ $(function() {
 	<!-- Credits view -->
 	<div id='caCredits'>
 		<div class='credits'>
+			<!-- In-body copy of the action buttons, shown only at <=767px where the
+			     top-bar copy is hidden (no room beside the close X). Same handler
+			     classes, so only the visible set is ever clickable. -->
+			<div class='caCreditsActionsBody ca_center'>
+				<div class='caButton caCreditsStatistics' role='button' tabindex='0'><?tr("Statistics");?></div>
+				<div class='caButton caCreditsChangeLog' role='button' tabindex='0'><?tr("Change Log");?></div>
+				<a class='caButton caCreditsSupport' href='https://forums.unraid.net/topic/38582-plug-in-community-applications/' target='_blank' rel='noopener noreferrer'><?tr("Help");?></a>
+			</div>
 			<div class='ca_center ca_creditVersion'><?tr("VERSION");?> <?=htmlspecialchars((string)ca_plugin("version","/var/log/plugins/community.applications.plg"), ENT_QUOTES)?><?if ($md5Error):?> <span class='modifiedCode'>Modified Code</span><?endif;?></div>
 			<div class='ca_center caLogoIcon'></div>
 			<div class='ca_center ca_creditTitle'>Community Applications</div>

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -1700,6 +1700,11 @@ body,
 		transform: translate(-50%, -50%);
 		z-index: 6;
 	}
+	/* In-body copy (at the top of the credits content) - desktop uses the top-bar
+	   copy above, so this is hidden until the <=767px rule in responsive.css. */
+	.caCreditsActionsBody {
+		display: none;
+	}
 	.ca_creditVersion {
 		margin-bottom: 0.75rem;
 		opacity: 0.85;
@@ -3427,7 +3432,6 @@ input[type="button"] {
 		z-index: 1000;
 	}
 	.searchArea {
-		/* padding-left: var(--search-area-left); */
 		background-color: revert;
 		display: flex;
 		flex-direction: row;
@@ -3499,7 +3503,7 @@ input[type="button"] {
 	body.ca_searchModalOpen {
 		overflow: hidden;
 	}
-	body.ca_searchModalOpen .caSearchModalToolbarSpaceca_searchModalOpenr {
+	body.ca_searchModalOpen .caSearchModalToolbarSpacer {
 		display: inline-block;
 		width: 2.5rem;
 		min-width: 2.5rem;
@@ -3530,9 +3534,6 @@ input[type="button"] {
 	body:has(.mobileMenu.menuShowing) .ca_modal_overlay {
 		left: 17rem;
 	}
-	body.Theme--sidebar:has(.mobileMenu.menuShowing) .ca_modal_overlay {
-		top: 0;
-	}
 	/* Pop the mobile menu above the scrim (default z-index 5 from responsive
 	   would put it under the z-index 999 overlay). Match the sidebar at 1000. */
 	body:has(.mobileMenu.menuShowing) .mobileMenu {
@@ -3542,6 +3543,12 @@ input[type="button"] {
 	   top 8rem of the viewport — pull the scrim down so the bar shows above it. */
 	body.menuShowing .ca_modal_overlay {
 		top: 8rem;
+	}
+	/* Sidebar theme has no such header bar, so the scrim starts at the very top
+	   whenever the menu (.menuItems.menuShowing) is open. .Theme--sidebar is on
+	   <html> (not body), so no body qualifier. */
+	.Theme--sidebar:has(.menuItems.menuShowing) .ca_modal_overlay {
+		top: 0;
 	}
 
 	/* While a SweetAlert is on screen the overlay must remain visible — other CA
@@ -3737,7 +3744,6 @@ input[type="button"] {
 	}
 
 	#searchBox {
-	/*	left: var(--search-area-left);*/
 		margin-left: 0rem;
 		margin-right: 0;
 		margin-bottom: 1rem;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.overrides.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.overrides.css
@@ -72,7 +72,7 @@ body.Theme--sidebar:has(.mfp-bg) #menu {
 }
 
 .Theme--sidebar .ca_display_area {
-	left: 65px;
+	left: var(--ca-sidebar-left, 65px);
 	/* `top` handled by the shared `.ca_display_area`/`.menuItems`
 	   calc in main CSS — applies to both layouts. */
 }
@@ -102,7 +102,7 @@ body.Theme--nav-top:has(.multi_installDiv:not(.ca_hide):not([style*="display: no
 	left: 0;
 }
 .Theme--sidebar .menuItems {
-   left: 65px;
+   left: var(--ca-sidebar-left, 65px);
    padding-left: 1rem;
 }
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
@@ -234,6 +234,21 @@ body:has(.ca_useWholeDisplayWindow) {
 		display: none;
 	}
 
+	/* Credits action buttons: on narrow viewports the top bar has no room beside
+	   the close X, so hide the top-bar copy and show the in-body copy at the top
+	   of the credits content instead. */
+	body:has(#sidenavContent .credits) .caCreditsActions {
+		display: none;
+	}
+	.caCreditsActionsBody {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.75rem;
+		margin-bottom: 1rem;
+	}
+
 	/* Nav-top theme on narrow viewports — small left inset so the search
 	   row doesn't sit flush against the viewport edge. */
 	.Theme--nav-top .searchArea {
@@ -293,14 +308,41 @@ body:has(.ca_useWholeDisplayWindow) {
 	.Theme--nav-top .searchAreaHolder {
 		padding-left: 0;
 	}
+	.Theme--sidebar {
+		--search-area-top: 0px;
+	}
+	/* Full-width fixed strip so the action icons can reach the viewport's
+	   right edge; the search controls themselves stay ~17rem on the left. */
 	.Theme--sidebar .searchAreaHolder {
 		background-color: var(--background-color);
-		width: 15rem;
-		padding-bottom: 0.75rem;
 	}
-	/* Only pull the search bar flush-left while the menu is showing. */
-	.Theme--sidebar .searchAreaHolder.menuShowing {
-		left: 0;
+	.Theme--sidebar .caSearchRowMain {
+		flex: 0 1 17rem;
+	}
+	/* Pin the info + settings icons to the top-right of the strip. */
+	.Theme--sidebar .caSearchRowEnd {
+		margin-left: auto;
+	}
+	/* Tighten the gap between the row icons on a phone-sized viewport. */
+	.Theme--sidebar .caSearchRowMain,
+	.Theme--sidebar .caSearchRowEnd {
+		gap: 0.125rem;
+	}
+	.Theme--sidebar .caSearchRowEnd :is(.caSettingsGear, .caCreditsInfo) {
+		padding-left: 0.25rem;
+		padding-right: 0.25rem;
+	}
+	/* Sidebar theme on a phone: collapse the OS-rail left offset so CA
+	   content and the search bar span the full width, and hide the
+	   persistent OS #menu. Both revert to their desktop values the moment
+	   the menu is opened (.menuItems.menuShowing), shifting content back
+	   to clear the rail and re-showing #menu as it was. */
+	.Theme--sidebar:not(:has(.menuItems.menuShowing)) {
+		--ca-sidebar-left: 0px;
+		--search-area-left: 0px;
+	}
+	.Theme--sidebar:not(:has(.menuItems.menuShowing)) #menu {
+		display: none;
 	}
 	/* Nav-top: narrow the search bar to make room for the open menu strip. */
 	.Theme--nav-top .searchAreaHolder.menuShowing {
@@ -351,9 +393,9 @@ body:has(.ca_useWholeDisplayWindow) {
 		padding-left: 1rem;
 	}
 	.Theme--sidebar .menuItems {
-		/* `top` removed — shared calc in main CSS handles it. */
+		/* top removed - shared calc in main CSS handles it. left removed -
+		   driven by --ca-sidebar-left (0 on mobile, 65px when the menu opens). */
 		bottom: 0;
-		left: 0px;
 	}
 
 	/* `.Theme--sidebar .ca_display_area` top removed — shared calc in


### PR DESCRIPTION
## What

Post-#98 UI work, CSS/HTML only.

### Sidebar-theme mobile layout (≤767px)
- Made the sidebar's `65px` OS-rail left offset a variable (`--ca-sidebar-left`, fallback `65px` so legacy <7.2 chrome — which never loads `responsive.css` — is unchanged). `.ca_display_area` and `.menuItems` consume it.
- On a phone, `.Theme--sidebar:not(:has(.menuItems.menuShowing))` collapses both `--ca-sidebar-left` and `--search-area-left` to `0` and hides the OS `#menu`, so the app list + search bar span the full width. The instant the menu is opened (`.menuItems.menuShowing`), the `:not(:has())` rule stops matching and everything reverts to its desktop values — no hardcoded restore.
- Search strip is now a full-width fixed bar (`width:17rem` removed from `.searchAreaHolder`) so the action group reaches the viewport edge; search controls stay ~17rem via `.caSearchRowMain { flex: 0 1 17rem }`, and `.caSearchRowEnd { margin-left:auto }` pins the info + gear icons top-right. Inter-icon gap tightened.
- `--search-area-top` set to `0px` at this breakpoint.

### Credits panel
- Statistics / Change Log / Help buttons render at the top of the Credits content on narrow screens (top bar has no room beside the close X). Same handler classes; only the visible set is clickable. Top-bar labels restored to full "Statistics" / "Change Log".

### Cleanup
- Fixed a corrupted selector (`caSearchModalToolbarSpace`**`ca_searchModalOpen`**`r`) that left the search pop-out toolbar spacer permanently hidden.
- Removed two dead commented-out declarations.

## Notes
- No `.plg` / `ca.md5` / `paths.php` changes.
- `plugins/CHANGES.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-optimized Credits action buttons for narrow viewports.

* **Bug Fixes**
  * Fixed spacing issue in the search bar.
  * Corrected mobile menu positioning in sidebar-style themes.

* **Improvements**
  * Enhanced responsive UI for sidebar theme on phones and narrow screens.
  * Clarified button labels (Stats → Statistics, Changes → Change Log).

* **Chores**
  * Removed unused styling code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->