### PR TITLE
feat: A-Z jump index for name-sorted categories

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -23,6 +23,7 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 
 ## Unreleased
 
+- Added: When browsing a category sorted by name that runs past five pages, an A-Z index strip appears down the right of the app list. Click a letter to jump straight to the apps starting with it; the current letter stays highlighted as you scroll, and grabbing the scrollbar shows a large letter for where you are. The strip thins itself to fit shorter windows and shows on Unraid 7.2 and newer (desktop only)
 - Changed: Home page sections now fill a full row of apps (instead of a fixed six), adapting to your window width and zoom. The last card in each section that links to a wider category is dimmed with a "Show More" label overlaid on it, opening that full category
 - Added: The Sort button now shows an icon for the current order (name A-Z / Z-A, downloads, or date added), and each entry in the Sort dropdown is led by its matching icon
 - Fixed: The category menu now opens correctly on Safari and iOS (iPhone / iPad) - it was being clipped to nothing when tapping the menu button

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -3106,6 +3106,100 @@ function postMultiDockerInstall() {
    caRenderPageNavigation script the server emits with each batch. Falls back
    to the loaded range when the layout signals aren't measurable, and hides
    itself on the home page / empty result. */
+function caUpdateAlphaBar(entries) {
+	var $bar = $("#caAlphaBar");
+	if (!$bar.length) return;
+	if (!$.isArray(entries) || !entries.length) {
+		$bar.addClass("ca_hide").empty();
+		return;
+	}
+	var perPage = Math.max(1, parseInt(data.maxPerPage, 10) || 1);
+	var perRow = (typeof caCardsPerRow === "function") ? Math.max(1, caCardsPerRow()) : 1;
+	var ordered = entries.slice().sort(function(a, b) {
+		return (parseInt(a && a.i, 10) || 0) - (parseInt(b && b.i, 10) || 0);
+	}).map(function(e) { return { l: e.l, i: parseInt(e.i, 10) || 0 }; });
+	data.alphaAll = ordered;
+	var kept = [];
+	var lastIdx = 0, lastPage = -1;
+	ordered.forEach(function(e) {
+		var i = parseInt(e && e.i, 10);
+		if (isNaN(i)) return;
+		var page = Math.floor(i / perPage);
+		if (kept.length && (page === lastPage || (i - lastIdx) < perRow)) return;
+		kept.push({ l: e.l, i: i });
+		lastIdx = i;
+		lastPage = page;
+	});
+	var render = function(list) {
+		var html = "";
+		list.forEach(function(e) {
+			var label = (e.l === "#") ? "#" : e.l.toUpperCase();
+			html += "<span class='caAlphaLetter' data-letter='" + e.l + "' data-index='" + e.i + "'>" + label + "</span>";
+		});
+		$bar.html(html).removeClass("ca_hide");
+		data.alphaShown = list;
+	};
+	render(kept);
+	var avail = $bar[0].clientHeight || 0;
+	var first = $bar.children().get(0);
+	var letterH = first ? first.offsetHeight : 0;
+	if (avail > 0 && letterH > 0) {
+		var maxFit = Math.floor(avail / letterH);
+		if (maxFit >= 1 && kept.length > maxFit) {
+			var stride = Math.ceil(kept.length / maxFit);
+			var thinned = [];
+			for (var k = 0; k < kept.length; k += stride) thinned.push(kept[k]);
+			render(thinned);
+		}
+		$bar.css("gap", Math.max(0, (avail - 27 * letterH) / 26) + "px");
+	}
+}
+
+function caAlphaLetterFor(list, globalIndex) {
+	if (!$.isArray(list) || !list.length) return null;
+	var active = list[0].l;
+	for (var k = 0; k < list.length; k++) {
+		if (list[k].i <= globalIndex) active = list[k].l;
+		else break;
+	}
+	return active;
+}
+
+function caUpdateAlphaActive(globalIndex) {
+	var $bar = $("#caAlphaBar");
+	if (!$bar.length || $bar.hasClass("ca_hide")) {
+		$(".caSpacerHintLetter").text("");
+		return;
+	}
+	var activeShown = caAlphaLetterFor(data.alphaShown, globalIndex);
+	$bar.find(".caAlphaLetter").removeClass("caAlphaActive");
+	if (activeShown !== null) {
+		$bar.find(".caAlphaLetter").filter(function() { return $(this).attr("data-letter") === activeShown; }).addClass("caAlphaActive");
+	}
+	var exact = caAlphaLetterFor(data.alphaAll, globalIndex);
+	$(".caSpacerHintLetter").text(exact === null ? "" : (exact === "#" ? "#" : exact.toUpperCase()));
+}
+
+function caJumpToLetter(letter) {
+	if (!letter) return;
+	post({ action: "jumpToLetter", letter: letter, maxPerPage: data.maxPerPage, selected: data.selected }, function(result) {
+		var dd = result.display_data || result.display;
+		var G = parseInt(result.index, 10);
+		if (!dd || isNaN(G) || G < 0) return;
+		if (dd.pageNumber) data.currentpage = parseInt(dd.pageNumber, 10) || 1;
+		updateDisplay(dd, false);
+		var ma = $(".mainArea")[0];
+		var $c = $("#templates_content .ca_templatesDisplay").find(".ca_holder");
+		var off = parseInt(caCardCache.offset, 10) || 0;
+		var idxInPage = G - off;
+		if (ma && $c.length && idxInPage >= 0 && idxInPage < $c.length) {
+			ma.scrollTop = $c[idxInPage].getBoundingClientRect().top - ma.getBoundingClientRect().top + ma.scrollTop;
+		} else {
+			scrollToTop();
+		}
+	});
+}
+
 function caUpdateDisplayCount() {
 	var $el = $(".ca_displayCount");
 	if (!$el.length) return;
@@ -3141,6 +3235,8 @@ function caUpdateDisplayCount() {
 	if (first > total) first = total;
 	if (last > total) last = total;
 	if (last < first) last = first;
+
+	if (typeof caUpdateAlphaActive === "function") caUpdateAlphaActive(first - 1);
 
 	var countText = first + " - " + last + " " + tr("of") + " " + total;
 	/* Append an "ALL RESULTS" affordance when the user has narrowed search
@@ -3186,6 +3282,8 @@ function caRenderStructuredFresh(content) {
  */
 function updateDisplay(content, append) {
 	var isStructured = content && typeof content === "object" && $.isArray(content.cards);
+
+	if (!append) caUpdateAlphaBar(isStructured ? content.alphaBar : null);
 
 	if (isStructured) {
 		if (append === "prepend") {
@@ -5751,7 +5849,7 @@ function caSpacerHintHtml() {
 	   keeps this label in sync with the toolbar "X - Y of Z" indicator as the
 	   user drags, showing where in the list they are scrubbing to. No extra wiring
 	   needed; the existing scroll-driven update populates it. */
-	return "<div class='caSpacerHint' aria-hidden='true'><span class='ca_displayCount'></span></div>";
+	return "<div class='caSpacerHint' aria-hidden='true'><span class='caSpacerHintLetter'></span><span class='ca_displayCount'></span></div>";
 }
 /* Virtualization: evict cards far above the viewport into a top-spacer (so
    scroll height stays the same) and restore them from caCardCache.cache when the
@@ -6732,6 +6830,7 @@ function caInitInfiniteScroll() {
 			   the bottom-padding variable so #sidenavContent never disappears
 			   behind a taller fixed bar after a resize. */
 			if (typeof caSyncSidenavBottomPadding === "function") caSyncSidenavBottomPadding();
+			if (typeof caRethinAlphaBar === "function") caRethinAlphaBar();
 		}, 150);
 		if (rebaseTimer) clearTimeout(rebaseTimer);
 		rebaseTimer = setTimeout(function() {
@@ -6742,6 +6841,28 @@ function caInitInfiniteScroll() {
 	$(window).on("resize", onResize);
 	if (window.visualViewport) {
 		$(window.visualViewport).on("resize", onResize);
+	}
+	// A resize or orientation change can alter the bar height without changing
+	// maxPerPage (which stays clamped at 12 or higher), so the viewport rebase
+	// skips. Re-thin the A-Z index for the new height when it is shown, debounced
+	// so resize and orientation triggers coalesce into one pass.
+	var alphaRethinTimer = null;
+	var caRethinAlphaBar = function() {
+		if (alphaRethinTimer) clearTimeout(alphaRethinTimer);
+		alphaRethinTimer = setTimeout(function() {
+			alphaRethinTimer = null;
+			var $bar = $("#caAlphaBar");
+			if ($bar.length && !$bar.hasClass("ca_hide") && $.isArray(data.alphaAll) && typeof caUpdateAlphaBar === "function") {
+				caUpdateAlphaBar(data.alphaAll);
+			}
+		}, 200);
+	};
+	if (window.matchMedia) {
+		var caOrientationMq = window.matchMedia("(orientation: portrait)");
+		if (caOrientationMq.addEventListener) caOrientationMq.addEventListener("change", caRethinAlphaBar);
+		else if (caOrientationMq.addListener) caOrientationMq.addListener(caRethinAlphaBar);
+	} else {
+		$(window).on("orientationchange", caRethinAlphaBar);
 	}
 }
 $(caInitInfiniteScroll);

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -3146,9 +3146,13 @@ function caUpdateAlphaBar(entries) {
 	if (avail > 0 && letterH > 0) {
 		var maxFit = Math.floor(avail / letterH);
 		if (maxFit >= 1 && kept.length > maxFit) {
-			var stride = Math.ceil(kept.length / maxFit);
 			var thinned = [];
-			for (var k = 0; k < kept.length; k += stride) thinned.push(kept[k]);
+			for (var n = 0; n < maxFit; n++) {
+				var idx = Math.round((n * (kept.length - 1)) / Math.max(1, maxFit - 1));
+				if (!thinned.length || thinned[thinned.length - 1].i !== kept[idx].i) {
+					thinned.push(kept[idx]);
+				}
+			}
 			render(thinned);
 		}
 		$bar.css("gap", Math.max(0, (avail - 27 * letterH) / 26) + "px");
@@ -3182,7 +3186,11 @@ function caUpdateAlphaActive(globalIndex) {
 
 function caJumpToLetter(letter) {
 	if (!letter) return;
+	caCardCache.generation = (caCardCache.generation || 0) + 1;
+	data.loadingMore = false;
+	var jumpGen = caCardCache.generation;
 	post({ action: "jumpToLetter", letter: letter, maxPerPage: data.maxPerPage, selected: data.selected }, function(result) {
+		if ((caCardCache.generation || 0) !== jumpGen) return;
 		var dd = result.display_data || result.display;
 		var G = parseInt(result.index, 10);
 		if (!dd || isNaN(G) || G < 0) return;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -140,6 +140,10 @@ switch ($_POST['action']) {
 		caRequireSkin();
 		display_content();
 		break;
+	case 'jumpToLetter':
+		caRequireSkin();
+		jumpToLetter();
+		break;
 	case 'dismiss_warning':
 		dismiss_warning();
 		break;
@@ -1898,6 +1902,42 @@ function display_content() {
 
 	$o['display_data'] = display_apps($pageNumber,$selectedApps,$startup,true);
 
+	postReturn($o);
+}
+
+function jumpToLetter() {
+
+	$letter = strtolower(trim(getPost("letter","")));
+	changeMax(getPost("maxPerPage",$GLOBALS['caSettings']['maxPerPage']));
+	$startup = getPost("startup",false);
+	$selectedApps = json_decode(getPost("selected",false),true);
+
+	$maxPerPage = (int)($GLOBALS['caSettings']['maxPerPage'] ?? 0);
+	if ( $maxPerPage < 1 ) {
+		$maxPerPage = 1;
+	}
+
+	$displayed = readJsonFile(CA_PATHS['community-templates-displayed']);
+	$list = $displayed['community'] ?? [];
+
+	$page  = 1;
+	$index = -1;
+	foreach ($list as $i => $template) {
+		$c = strtolower(substr(trim($template['SortName'] ?? ""),0,1));
+		if ( $c === "" ) {
+			continue;
+		}
+		$isNum = ($c >= "0" && $c <= "9");
+		$match = ($letter === "#") ? $isNum : ($c === $letter);
+		if ( $match ) {
+			$index = $i;
+			$page  = intdiv($i,$maxPerPage) + 1;
+			break;
+		}
+	}
+
+	$o['display_data'] = display_apps($page,$selectedApps,$startup,true);
+	$o['index']        = $index;
 	postReturn($o);
 }
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -797,6 +797,9 @@ function caInitializeClickHandlers() {
 		post({ action: "changeSortOrder", sortOrder: sortOrder }, function() { getContent(false, category, description, false); });
 	});
 	$(".dockerSearch").click(function() { caClearHomeSectionSubtitle(); initDockerSearch(); });
+	$("body").on("click", "#caAlphaBar .caAlphaLetter:not(.caAlphaOff)", function() {
+		caJumpToLetter($(this).attr("data-letter"));
+	});
 	/**
 	 * "Show All Results" affordance on the display-count line: widens the
 	 * current search by setting the one-shot override flag and re-running

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
@@ -128,6 +128,8 @@ $(function() {
 <!-- Main Display Area -->
 <div class='ca_display_area'>
 
+	<div id='caAlphaBar' class='ca_hide hideWithMenu' aria-hidden='true'></div>
+
 	<div class='mainArea menuAdjust'>
 
 		<div id='templates_content' class='menuAdjust'></div>

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.php
@@ -892,6 +892,51 @@ function displayPopup($template) {
  * @param bool $returnArray When true, return HTML string only (no echo path)
  * @return array|string|void
  */
+function caBuildAlphaBar($list) {
+	global $sortOrder;
+
+	// Apps A-Z index is 7.2+ only (relies on the responsive layout CSS vars).
+	if ( ! version_compare((string)($GLOBALS['caSettings']['unRaidVersion'] ?? "0"), "7.1.9999", ">") ) {
+		return null;
+	}
+	if ( ! in_array($sortOrder['sortBy'] ?? "", ["Name","SortName"], true) ) {
+		return null;
+	}
+	$maxPerPage = (int)($GLOBALS['caSettings']['maxPerPage'] ?? 0);
+	if ( $maxPerPage < 1 || ceil(count($list) / $maxPerPage) <= 5 ) {
+		return null;
+	}
+
+	$first = [];
+	foreach ($list as $i => $template) {
+		$c = strtolower(substr(trim($template['SortName'] ?? ""),0,1));
+		if ( $c >= "a" && $c <= "z" ) {
+			$key = $c;
+		} elseif ( $c >= "0" && $c <= "9" ) {
+			$key = "#";
+		} else {
+			continue;
+		}
+		if ( ! isset($first[$key]) ) {
+			$first[$key] = $i;
+		}
+	}
+	if ( ! $first ) {
+		return null;
+	}
+
+	$out = [];
+	if ( isset($first["#"]) ) {
+		$out[] = ['l'=>"#", 'i'=>$first["#"]];
+	}
+	foreach (range("a","z") as $l) {
+		if ( isset($first[$l]) ) {
+			$out[] = ['l'=>$l, 'i'=>$first[$l]];
+		}
+	}
+	return $out;
+}
+
 function display_apps($pageNumber=1,$selectedApps=false,$startup=false,$returnArray=false) {
 
 	$filesToCheck = [
@@ -901,9 +946,11 @@ function display_apps($pageNumber=1,$selectedApps=false,$startup=false,$returnAr
 	];
 
 	$file = [];
+	$usedPath = null;
 	foreach ($filesToCheck as $path) {
 		if ($path && is_file($path)) {
 			$file = readJsonFile($path);
+			$usedPath = $path;
 			break;
 		}
 	}
@@ -915,7 +962,14 @@ function display_apps($pageNumber=1,$selectedApps=false,$startup=false,$returnAr
 	$totalApplications = count($communityApplications);
 
 	if ($totalApplications) {
-		return my_display_apps($communityApplications,$pageNumber,$selectedApps,$startup,$returnArray);
+		$result = my_display_apps($communityApplications,$pageNumber,$selectedApps,$startup,$returnArray);
+		if ($returnArray && is_array($result) && $usedPath === (CA_PATHS['community-templates-displayed'] ?? null)) {
+			$alphaBar = caBuildAlphaBar($communityApplications);
+			if ($alphaBar) {
+				$result['alphaBar'] = $alphaBar;
+			}
+		}
+		return $result;
 	}
 
 	$emptyHtml = "<div class='ca_NoAppsFound'>".tr("No Matching Applications Found")."</div>".caBuildSearchLimitHintHtml()."<script>$('.multi_installDiv').hide();hideSortIcons();</script>";

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -458,6 +458,36 @@ body,
 	margin-top: 0.25rem;
 }
 
+#caAlphaBar {
+	position: fixed;
+	right: 3rem;
+	top: calc(var(--ca-header-image-height) + var(--ca-menu-height) + var(--ca-theme-top-offset) + 1rem);
+	bottom: 6rem;
+	z-index: 5;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	font-size: 1.6rem;
+	line-height: 1;
+	user-select: none;
+	-webkit-user-select: none;
+}
+.caAlphaLetter {
+	cursor: pointer;
+	padding: 0 0.3rem;
+	border-radius: 0.2rem;
+	transition: transform 0.08s ease;
+}
+.caAlphaLetter:hover {
+	color: var(--brand-orange);
+	transform: scale(2.5);
+}
+.caAlphaActive {
+	color: var(--brand-orange);
+	font-weight: bold;
+}
+
 /* 2.3) Card Elements */
 .ca_applicationName {
 	/* Layout */
@@ -2208,6 +2238,18 @@ body,
 		background-color: var(--text-color);
 		color: var(--background-color);
 		box-shadow: 0 2px 12px var(--ca-shadow-color);
+	}
+	.caSpacerHint .caSpacerHintLetter {
+		display: block;
+		font-size: 10rem;
+		line-height: 1;
+		font-weight: 700;
+		color: var(--text-color);
+		text-shadow: 0 2px 12px var(--ca-shadow-color);
+		margin-bottom: 1rem;
+	}
+	.caSpacerHint .caSpacerHintLetter:empty {
+		display: none;
 	}
 
 	.ca_twitter::before {

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.responsive.css
@@ -172,6 +172,10 @@ body:has(.ca_useWholeDisplayWindow) {
 	}
 }
 @media (max-width: 767px) {
+	/* A-Z jump bar is desktop-only. */
+	#caAlphaBar {
+		display: none !important;
+	}
 	/* At narrow viewports the nav-top toolbar wraps onto a second line,
 	   so the reserved menu height doubles from 4rem (one row) to 8rem
 	   (two rows). Sidebar layout doesn't have a top toolbar, so its


### PR DESCRIPTION
Adds a vertical **A–Z index** down the right of the app grid that lets you jump straight to apps starting with a given letter, for name-sorted category views that run past five virtual pages. **Unraid 7.2+, desktop only.**

## Behaviour
- Shows only when: a plain category view (the displayed cache, not search/repos), sorted by **Name** (asc or desc), with **> 5** pages, on **7.2+**, viewport **≥ 768px**.
- **Index-ordered** — follows the sort direction (A→Z ascending, Z→A descending), so a letter's position in the strip matches where its apps sit in the list.
- **Numerals fold into `#`**; CJK/symbol-leading apps get no entry. Letters are **not translated** (they match the untranslated app names).
- **Collapses** letters whose first app shares a page (or sits within a row) of an already-shown one.
- **Thins to fit** — when the list is taller than the available height, drops every Nth letter evenly (no resizing). Re-thins on resize *and* orientation change (since `maxPerPage` is floored at 12 and often doesn't change).
- **Centred** with a fixed full-27-bar gap, so a few letters cluster neatly instead of stretching edge to edge.
- **Active highlight** — the letter for the current scroll position stays lit (brand orange, not scaled); one is always lit and it updates as you scroll. Hover scales the glyph 2.5× from centre.
- **Scrollbar grab** — the existing centred "x of y" overlay now also shows a large (10rem) current letter above it (the exact letter, even if that letter is thinned from the strip).

## How it works
- **Server** [`caBuildAlphaBar`](skins/Narrow/skin.php) returns `[{l, i}, …]` (letter + first-app global index), gated as above. [`jumpToLetter`](include/exec.php) finds the first matching index, converts to a page, renders it, and returns the page + the match's index.
- **Client** [`caUpdateAlphaBar`](Apps.page) sorts/collapses/thins and renders; [`caJumpToLetter`](Apps.page) applies the rendered page like `changePage`'s full-replace, then scrolls the matched card to the top (reusing the `caRebaseForViewport` landing technique, so spacers/scrollbar/"x of y" stay in sync). `caUpdateDisplayCount` drives the active highlight + big grab letter on every scroll.

## Notes
- `plugins/CHANGES.md` updated; `.plg` and `ca.md5` left untouched.
- `php -l` clean on the PHP files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an A–Z index bar for name-sorted app categories (desktop, Unraid 7.2+) when lists span >5 pages — tap letters to jump to letters, with scroll-aware highlighting, scrollbar integration, adaptive thinning to fit available height, and automatic hiding on narrow/mobile viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->