### PR TITLE
feat: auto-adjust conflicting host ports during install

### DIFF
--- a/plugins/CHANGES.md
+++ b/plugins/CHANGES.md
@@ -247,3 +247,10 @@ the packaged plugin (`pkg_build.sh` only ships `source/community.applications/`)
 - Changed: The Monthly Spotlight date now sits left-aligned under the spotlight icon (on app cards and in the app panel) instead of being centred beneath it
 - Changed: The "Installed" badge now adapts its colour to light and dark themes so it stays legible on both
 - Changed: A complete factory reset ("Delete all setting files") now also clears the list of ignored repositories
+- Added: Community Applications can now automatically adjust a container's host ports during installation when they clash with something already running on your server, or with a container that is installed but stopped. Anything it changed is listed for you on the Add Container page after install. This is on by default and can be turned off with the new "Adjust Ports" setting
+- Changed: Reinstalling a previously installed app from the sidebar now checks it for host port conflicts and warns you, leaving your saved template untouched rather than changing its ports
+- Changed: Installing several apps at once from Previous Apps now skips any whose host ports would clash (with your server or with another app being installed in the same batch) and tells you which to install one at a time, instead of installing them with conflicting ports
+- Added: The Previous Apps sidebar now offers "Install Default" (install the current template from the feed) alongside "Reinstall" (your previously saved template)
+- Added: When viewing an app you do not currently have installed but have installed before, the sidebar now offers a "Reinstall" button for your saved template alongside "Install Default"
+- Fixed: Uninstalling an app from the sidebar now immediately updates its card to show it is no longer installed, instead of leaving the old badges in place until the next refresh
+- Changed: Hovering the "Show More" card on the home page now highlights it the same way a normal app card highlights on hover

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -2994,7 +2994,19 @@ function installMulti() {
 			return;
 		}
 		post({action:'checkMultiPortConflicts',templates:JSON.stringify(docker),noSpinner:true},function(res) {
-			var conflicts = (res && res.conflicts) ? res.conflicts : [];
+			if ( ! res || ! Array.isArray(res.conflicts) ) {
+				swal({
+					title: "<?tr("Unable to verify port conflicts");?>",
+					text: "<?tr("Please try again. The installation was not started.");?>",
+					type: "error",
+					showConfirmButton: true,
+					allowOutsideClick: true
+				}, function() {
+					enableSearch();
+				});
+				return;
+			}
+			var conflicts = res.conflicts;
 			if ( ! conflicts.length ) {
 				proceed();
 				return;
@@ -3002,8 +3014,9 @@ function installMulti() {
 			var skip = {};
 			var msg = "<?tr("The following were skipped due to port conflicts. To install each, click Install on the application card and then Reinstall from the sidebar:");?>";
 			conflicts.forEach(function(c){
+				var safeName = $("<div>").text(c.name || "").html();
 				skip[c.name] = true;
-				msg += "<br><strong>"+c.name+"</strong>";
+				msg += "<br><strong>"+safeName+"</strong>";
 			});
 			docker = docker.filter(function(name){ return ! skip[name]; });
 			dockerCount = docker.length;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/Apps.page
@@ -374,7 +374,6 @@ var postCount = 0;
 var cookieWarning = false;
 var restoreStateMenu = false;
 var resizeTimer;
-var portsInUse = [];
 var startupSearch = <?= json_encode($startupSearch, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>;
 var startupTemplateURL = <?= json_encode($startupTemplateURL, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>;
 var ca_done_override = false;
@@ -831,12 +830,6 @@ $(function(){
 		return;
 
 		<?else:?>
-	// don't run this through the wrapper so that if it hangs up it won't delay anything else
-	$.post(execURL,{action:'getPortsInUse'},function(ret) {
-		portsInUse = ret.portsInUse;
-		caDebug("Ports In Use:" + portsInUse);
-	});
-
 	if ( "<?=$startupDisplayed?>" == "true" && caSessGet("ca_languageSwitch") ) { // This is needed so that if language gets switched on the home page the home page gets regenerated correctly
 		caSessRemove("ca_languageSwitch");
 	}
@@ -2501,23 +2494,16 @@ function uninstallDocker(application,humanName) {
 		if ( isConfirm ) {
 			myAlert("",sprintf("<?tr("Uninstalling %s")?>",humanName));
 			post({action:'uninstall_docker',application:application,noSpinner:true},function(result) {
-				if ( $(".selectedMenu").length == 0 ) {
-					appStore();
-				} else {
-					myCloseAlert();
-				}
 				enableSearch();
 				caRefreshInstalledMenuStates();
-				if ( $(".selectedMenu").data("category") == "action_centre" ) {
-					post({action:'getPortsInUse'},function(data) {
-						portsInUse = data.portsInUse;
-						actionCentre();
-					});
+				if ( $(".selectedMenu").length == 0 ) {
+					appStore();
+				} else if ( $(".selectedMenu").data("category") == "action_centre" ) {
+					myCloseAlert();
+					actionCentre();
 				} else {
-					post({action:'getPortsInUse'},function(data) {
-						portsInUse = data.portsInUse;
-						$(".selectedMenu").trigger("click");
-					});
+					myCloseAlert();
+					refreshDisplay();
 				}
 			});
 		} else {
@@ -2643,94 +2629,30 @@ function pins() {
 }
 
 /**
- * Open branch/rename flows for a template: checks host port conflicts, optionally asks to auto-adjust, then `displayTags` in a SweetAlert chooser.
+ * Open the branch/rename chooser for a template in a SweetAlert.
  *
  * @param {string} leadTemplate Primary template identifier for `displayTags`
  * @param {boolean} [rename=false] Rename-vs-install mode for PHP
- * @param {string} [ports=''] JSON array of template ports (string) to cross-check against `portsInUse`
  */
-function displayTags(leadTemplate,rename=false,ports="") {
+function displayTags(leadTemplate,rename=false) {
 	event.stopPropagation();
-	/* Deliberately do NOT closeSidebar() here — the swal modal floats over the
-	   sidebar (same as popupInstallXML's port-conflict prompt), which both
-	   keeps the look-and-feel consistent and avoids the cancel/install reopen
-	   gymnastics of explicitly tearing it down and restoring identity. The
-	   install path (.xmlInstall → actuallyInstallPlugin) handles its own
-	   closeSidebar(true) when the user picks a branch. */
-	var conflictingPorts = [];
-
-	if ( ports ) {
-		try {
-			ports = JSON.parse(ports);
-		} catch(e) {
-			ports = [];
-		}
-		if ( ports ) {
-			ports.forEach(function(port){
-				portsInUse.forEach(function(used) {
-					if (port == used && conflictingPorts.indexOf(port) < 0)
-						conflictingPorts.push(port);
-				});
-			});
-		}
-	}
-
-	/* The .xmlInstall click handler reads window.caPendingAdjustPorts when the
-	   user picks a branch from the chooser swal below — that's how this Yes/No
-	   answer reaches the createXML POST. Reset to false on every entry so a
-	   stale "yes" from a prior template doesn't leak. */
-	window.caPendingAdjustPorts = false;
-
-	var openBranchChooser = function() {
-		post({action:'displayTags',leadTemplate:leadTemplate,noSpinner:true,rename:rename},function(result) {
-			disableSearch();
-			swal({
-				title: "<?tr("Choose A Branch To Install");?>",
-				text: result.tags,
-				html: true,
-				type: "warning",
-				showCancelButton: true,
-				showConfirmButton: false,
-				cancelButtonText: "<?tr("Cancel");?>",
-				allowOutsideClick: true
-			}, function(isConfirm) {
-				if ( ! isConfirm ) {
-					enableSearch();
-				}
-			});
-		});
-	};
-
-	if (conflictingPorts.length) {
-		var portList = conflictingPorts.join(", ");
-		var portTemplate = (conflictingPorts.length === 1)
-			? "<?tr("Port %s used by this application is already in use by another service or app running on your server.");?>"
-			: "<?tr("Ports %s used by this application are already in use by another service or app running on your server.");?>";
-		var msg = portTemplate.replace("%s", portList);
-		msg += " <?tr("Would you like CA to automatically adjust the conflicting host ports?");?>";
+	post({action:'displayTags',leadTemplate:leadTemplate,noSpinner:true,rename:rename},function(result) {
+		disableSearch();
 		swal({
-			title: "<?tr("Port Conflict");?>",
-			text: msg,
-			allowOutsideClick: true,
-			showConfirmButton: true,
-			showCancelButton: true,
-			confirmButtonText: "<?tr("Yes, adjust automatically");?>",
-			cancelButtonText: "<?tr("No, install anyway");?>",
-			animation: false,
-			type: "warning",
+			title: "<?tr("Choose A Branch To Install");?>",
+			text: result.tags,
 			html: true,
-			/* Both kept open so the branch-chooser swal can replace this one
-			   cleanly — letting either close first eats the next swal in the
-			   transition. */
-			closeOnConfirm: false,
-			closeOnCancel: false
+			type: "warning",
+			showCancelButton: true,
+			showConfirmButton: false,
+			cancelButtonText: "<?tr("Cancel");?>",
+			allowOutsideClick: true
 		}, function(isConfirm) {
-			window.caPendingAdjustPorts = !!isConfirm;
-			openBranchChooser();
+			if ( ! isConfirm ) {
+				enableSearch();
+			}
 		});
-	} else {
-		openBranchChooser();
-	}
+	});
 }
 
 /**
@@ -3037,8 +2959,16 @@ function installMulti() {
 		allowOutsideClick: true,
 		html: true
 	}, function( isConfirm ) {
-		if ( isConfirm ) {
+		if ( ! isConfirm ) {
+			enableSearch();
+			return;
+		}
+		var proceed = function() {
 			myCloseAlert();
+			if ( ! docker.length && ! plugin.length ) {
+				enableSearch();
+				return;
+			}
 			if ( docker.length && plugin.length ) {
 				caSessSet("ca_plugininstallpending",plugin);
 			}
@@ -3058,9 +2988,36 @@ function installMulti() {
 
 				enableSearch();
 			}
-		} else {
-			enableSearch();
+		};
+		if ( ! docker.length ) {
+			proceed();
+			return;
 		}
+		post({action:'checkMultiPortConflicts',templates:JSON.stringify(docker),noSpinner:true},function(res) {
+			var conflicts = (res && res.conflicts) ? res.conflicts : [];
+			if ( ! conflicts.length ) {
+				proceed();
+				return;
+			}
+			var skip = {};
+			var msg = "<?tr("The following were skipped due to port conflicts. To install each, click Install on the application card and then Reinstall from the sidebar:");?>";
+			conflicts.forEach(function(c){
+				skip[c.name] = true;
+				msg += "<br><strong>"+c.name+"</strong>";
+			});
+			docker = docker.filter(function(name){ return ! skip[name]; });
+			dockerCount = docker.length;
+			swal({
+				title: "<?tr("Port Conflicts");?>",
+				text: msg,
+				type: "warning",
+				html: true,
+				showConfirmButton: true,
+				allowOutsideClick: true
+			}, function(){
+				proceed();
+			});
+		});
 	});
 }
 
@@ -4006,64 +3963,24 @@ function setFavourite(button) {
  * @param {string} type Template type slot (`default` / `second` / …)
  * @param {string} [ports=''] JSON list of ports (string) used for conflict detection
  */
-function popupInstallXML(xml,type,ports="") {
+function popupInstallXML(xml,type) {
 	event.stopPropagation();
 	saveState();
-	var conflictingPorts = [];
-	if ( ports ) {
-		try {
-			ports = JSON.parse(ports);
-		} catch(e) {
-			ports = [];
-		}
-		if ( ports ) {
-			ports.forEach(function(port){
-				portsInUse.forEach(function(used) {
-					if (port == used && conflictingPorts.indexOf(port) < 0)
-						conflictingPorts.push(port);
-				});
-			});
-		}
-	}
-
-	if (conflictingPorts.length) {
-		/* Ports collide with something already on the host. Offer to auto-adjust
-		   them — Yes adjusts the XML server-side before opening AddContainer,
-		   No leaves the template alone (user fixes manually in the docker UI). */
-		var portList = conflictingPorts.join(", ");
-		var portTemplate = (conflictingPorts.length === 1)
-			? "<?tr("Port %s used by this application is already in use by another service or app running on your server.");?>"
-			: "<?tr("Ports %s used by this application are already in use by another service or app running on your server.");?>";
-		var msg = portTemplate.replace("%s", portList);
-		msg += " <?tr("Would you like CA to automatically adjust the conflicting host ports?");?>";
-		swal({
-			title: "<?tr("Port Conflict");?>",
-			text: msg,
-			allowOutsideClick: true,
-			showConfirmButton: true,
-			showCancelButton: true,
-			confirmButtonText: "<?tr("Yes, adjust automatically");?>",
-			cancelButtonText: "<?tr("No, install anyway");?>",
-			animation: false,
-			type: "warning",
-			html: true
-		}, function (isConfirm) {
-			installXML(xml, type, isConfirm);
-		});
-	} else {
-		installXML(xml,type,false);
-	}
+	installXML(xml,type);
 }
 /**
  * Ask PHP to materialize a Docker XML template (`createXML`), then open `/Apps/AddContainer` with the returned template handle.
  *
  * @param {string} xml
  * @param {string} type
- * @param {boolean} adjustPorts When true, server should remap conflicting host ports
  */
-function installXML(xml,type,adjustPorts) {
-	post({action:'createXML',xml:xml,type:type,adjustPorts:!!adjustPorts},function(result){
+function installXML(xml,type) {
+	post({action:'createXML',xml:xml,type:type},function(result){
 		if ( result.status == "ok" ) {
+			// Server remapped conflicting host ports — stash the note so the
+			// AddContainer page can surface it once (ca_browser_back_helper.page).
+			if (result.portAdjustMessage)
+				caSessSet("ca_port_adjustments", result.portAdjustMessage);
 			if (type == "second") {
 				type = "default";
 			}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/ca_browser_back_helper.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/ca_browser_back_helper.page
@@ -20,7 +20,7 @@ Link='nav-user'
 // the "Done" button (in which case document.referrer comes back empty).
 //
 // Uses location.pathname rather than href.includes/endsWith so query-string
-// variants (/Apps?foo=bar) or fragments don't confuse the matcher — only
+// variants (/Apps?foo=bar) or fragments don't confuse the matcher - only
 // the actual path component decides whether we're on a CA child page, the
 // bare /Apps root, or somewhere else entirely.
 $(function() {
@@ -29,7 +29,7 @@ $(function() {
 	var isAppsChild = (p.indexOf("/Apps/") === 0) && !isAppsRoot;
 	if (isAppsChild) {
 		try { sessionStorage.setItem("ca_apps_referrer","true"); } catch (e) { /* no-op */ }
-		// User just arrived on a CA child page (Install / Edit / etc.) — drop
+		// User just arrived on a CA child page (Install / Edit / etc.) - drop
 		// the docker info cache so when they bounce back to /Apps the listing
 		// rebuilds from live state. Fire-and-forget; no UI on these pages.
 		try {
@@ -37,11 +37,50 @@ $(function() {
 				{ action: "dropInfoCache", noSpinner: 1 });
 		} catch (e) { /* no-op */ }
 	} else if (p.indexOf("/Apps") !== 0) {
-		// Off CA entirely — reset. On the bare /Apps root, leave the value alone
+		// Off CA entirely - reset. On the bare /Apps root, leave the value alone
 		// so the restore branch in Apps.page can still see "true" from a prior
 		// child-page visit when the user lands back here.
 		try { sessionStorage.setItem("ca_apps_referrer","false"); } catch (e) { /* no-op */ }
 	}
+
+	// Port-adjustment handoff: createXML stashed a note describing the host
+	// ports it remapped to dodge conflicts, right before navigating here. Show
+	// it once on AddContainer, then clear it. If we landed anywhere else the
+	// note is stale (navigation didn't go where we expected) so drop it without
+	// showing - better than having it pop up later on an unrelated page.
+	//
+	// The note is already fully translated by CA's createXML (this page runs on
+	// AddContainer, which has no access to CA's tr() tables) so we display it
+	// verbatim - no tr() here.
+	try {
+		var portNote = sessionStorage.getItem("ca_port_adjustments");
+		if (portNote) {
+			sessionStorage.removeItem("ca_port_adjustments");
+			if (p === "/Apps/AddContainer" && typeof swal === "function") {
+				// Already-translated {title,text} blob built by CA's createXML.
+				var note = JSON.parse(portNote);
+				var showPortSwal = function() {
+					swal({
+						title: note.title,
+						text: note.text,
+						type: "info",
+						html: true,
+						showConfirmButton: true,
+						confirmButtonText: "_(OK)_"
+					});
+				};
+				// Wait 1.5s, then hold off while the page spinner is up (re-check
+				// every 1s) so the notice doesn't land on top of a loading overlay.
+				setTimeout(function waitForSpinner() {
+					if ($(".spinner").is(":visible")) {
+						setTimeout(waitForSpinner, 1000);
+					} else {
+						showPortSwal();
+					}
+				}, 1500);
+			}
+		}
+	} catch (e) { /* no-op */ }
 });
 </script>
 

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/ca_browser_back_helper.page
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/ca_browser_back_helper.page
@@ -70,9 +70,11 @@ $(function() {
 					});
 				};
 				// Wait 1.5s, then hold off while the page spinner is up (re-check
-				// every 1s) so the notice doesn't land on top of a loading overlay.
+				// every 1s, up to 10 tries) so the notice doesn't land on top of a
+				// loading overlay - but still show it if the spinner gets stuck.
+				var caPortSwalTries = 0;
 				setTimeout(function waitForSpinner() {
-					if ($(".spinner").is(":visible")) {
+					if (caPortSwalTries++ < 10 && $(".spinner").is(":visible")) {
 						setTimeout(waitForSpinner, 1000);
 					} else {
 						showPortSwal();

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/default.cfg
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/default.cfg
@@ -1,6 +1,7 @@
 hideIncompatible="true"
 hideDeprecated="true"
 defaultReinstall="false"
+adjustPorts="yes"
 debugging="no"
 updateCheck="yes"
 dev="no"

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -252,6 +252,9 @@ switch ($_POST['action']) {
 	case 'createXML':
 		createXML();
 		break;
+	case 'checkMultiPortConflicts':
+		checkMultiPortConflicts();
+		break;
 	case 'switchLanguage':
 		switchLanguage();
 		break;
@@ -295,9 +298,6 @@ switch ($_POST['action']) {
 	case 'showInApps':
 		caRequireSkin();
 		showInApps();
-		break;
-	case 'getPortsInUse':
-		postReturn(["portsInUse"=>getPortsInUse()]);
 		break;
 	case 'getLastUpdate':
 		postReturn(['lastUpdate'=>getLastUpdate(getPost("ID","Unknown"))]);
@@ -724,8 +724,6 @@ function processApplicationFeed(array $ApplicationFeed, string $currentFeed): bo
 
 		$o = fixTemplates($o);
 		if ( ! $o ) continue;
-
-		$o['PortsUsed'] = portsUsed($o);
 
 		if ( is_array($o['trends']??null) && count($o['trends']) > 1 ) {
 			$o['trendDelta'] = round(end($o['trends']) - $o['trends'][0],4);
@@ -1175,7 +1173,7 @@ function saveSettings() {
 	$switches = [
 		"defaultReinstall", "updateCheck", "useWholeDisplayWindow", "searchLimitToName",
 		"keepSearchInFocus", "displayUsageGraphs", "hideDeprecated", "hideIncompatible",
-		"featuredDisable", "dev", "autoplayVideos",
+		"featuredDisable", "adjustPorts", "dev", "autoplayVideos",
 	];
 	foreach ($switches as $key) {
 		$posted = getPost($key, null);
@@ -2942,6 +2940,60 @@ function caExtractXmlEntities(string $xml): array {
 }
 
 /**
+ * Check a batch of stored docker templates (Previous Apps multi-install) for
+ * host-port conflicts. The multi-install pushes templates straight to dockerMan
+ * with no per-app input, so any that collide must be installed individually via
+ * the sidebar instead. Returns the conflicting ones so the client can skip them.
+ *
+ * Conflicts are tested in list order against a running set of taken ports that
+ * starts with what is already in use (live plus stopped bridge containers) and
+ * grows as each non-conflicting app is accepted. So an app is flagged if it
+ * collides with the host OR with an earlier-accepted app in the same batch; the
+ * earlier app stays, the later one is dropped. The first app never self-conflicts.
+ *
+ * Reads POST templates (JSON array of app names, as sent by installMulti - the
+ * checkbox data-name). Each resolves to its saved dockerMan template
+ * (my-NAME.xml). No-op (empty list) when the "Adjust Ports" setting is off.
+ * Calls postReturn().
+ *
+ * @return void
+ */
+function checkMultiPortConflicts() {
+	$names = json_decode(getPost("templates", "[]"), true);
+	if ( ! is_array($names) ) $names = [];
+
+	$conflicting = [];
+	if ( ($GLOBALS['caSettings']['adjustPorts'] ?? "yes") === "yes" ) {
+		$taken = [];
+		foreach (array_merge(getPortsInUse(), getStoppedBridgePorts(getAllInfo())) as $p) {
+			$pi = (int)$p;
+			if ($pi > 0) $taken[$pi] = true;
+		}
+		foreach ($names as $name) {
+			// update_container resolves these names to my-NAME.xml in templates-user;
+			// match that, with a space->dash fallback for older saved filenames.
+			$path = CA_PATHS['dockerManTemplates']."/my-".$name.".xml";
+			if ( ! is_file($path) )
+				$path = CA_PATHS['dockerManTemplates']."/my-".str_replace(" ","-",$name).".xml";
+			$template = readXmlFile($path, false, false);
+			if ( ! is_array($template) ) continue;
+			$ports = getTemplateBridgePorts($template);
+			$hasConflict = false;
+			foreach ($ports as $port) {
+				if ( isset($taken[$port]) ) { $hasConflict = true; break; }
+			}
+			if ( $hasConflict ) {
+				$conflicting[] = ["name"=>$name];
+			} else {
+				// Accepted - reserve its ports so later apps in the batch see them.
+				foreach ($ports as $port) $taken[$port] = true;
+			}
+		}
+	}
+	postReturn(["conflicts"=>$conflicting]);
+}
+
+/**
  * Build the dockerMan install XML for a container template and write it to disk.
  *
  * Reads POST xml (template path) and type ("second" for rename flow), looks
@@ -3158,15 +3210,63 @@ function createXML() {
 			}
 		}
 
-		// Auto-adjust conflicting host ports when the client opted in via the
-		// "Adjust automatically?" prompt during install.
-		if ( filter_var(getPost("adjustPorts", false), FILTER_VALIDATE_BOOLEAN) ) {
-			adjustTemplatePorts($template, getPortsInUse());
+		// Auto-adjust conflicting host ports here, server-side, against the freshly
+		// built template (full Config is available post-hydrate). Gated on the
+		// "Adjust Ports" setting (default yes); the AddContainer swal tells the user
+		// after the fact. Each remap becomes a translated line the client stashes in
+		// sessionStorage and shows once on AddContainer load (ca_browser_back_helper.page).
+		// Ports in use = live listeners (lsof) PLUS host ports claimed by installed-
+		// but-stopped bridge containers (which lsof can't see but would clash on start).
+		if ( ($GLOBALS['caSettings']['adjustPorts'] ?? "yes") === "yes" ) {
+			$portsInUse = array_merge(getPortsInUse(), getStoppedBridgePorts($alreadyInstalled));
+			$portChanges = adjustTemplatePorts($template, $portsInUse);
+			$lines = [];
+			foreach ($portChanges as $c) {
+				$label = $c['label'] ?? "";
+				if ( $label !== "" )
+					$lines[] = sprintf(tr('<strong>%1$s</strong> port <strong>%2$s</strong> to <strong>%3$s</strong>'), $label, $c['from'], $c['to']);
+				else
+					$lines[] = sprintf(tr('port <strong>%1$s</strong> to <strong>%2$s</strong>'), $c['from'], $c['to']);
+			}
+			// Translate everything here, where CA's language tables are loaded. The
+			// AddContainer page that ultimately shows this has no access to CA's tr()
+			// tables, so we hand it a ready-to-display {title,text} blob it renders
+			// verbatim.
+			if ( $lines )
+				$portAdjustMessage = json_encode([
+					"title" => tr("Conflicting ports adjusted"),
+					"text"  => implode("<br>", $lines),
+				]);
 		}
 
 		$xml = makeXML($template);
 		@mkdir(dirname($xmlFile),0777,true);
 		ca_file_put_contents($xmlFile,$xml);
+	} elseif ( $type === "user" ) {
+		// Reinstall: a previously-installed (now removed) template pushed straight
+		// back to dockerMan. The container no longer exists, so its own ports can't
+		// self-conflict. We must NOT rewrite the user's saved template, so we only
+		// CHECK it for host-port conflicts and warn via the AddContainer swal. Edit
+		// (type "edit") is for a still-installed container and is exempt. Gated on
+		// the same "Adjust Ports" setting.
+		if ( ($GLOBALS['caSettings']['adjustPorts'] ?? "yes") === "yes" ) {
+			$storedTemplate = readXmlFile($xmlFile, false, false);
+			if ( is_array($storedTemplate) ) {
+				$portsInUse = array_merge(getPortsInUse(), getStoppedBridgePorts(getAllInfo()));
+				$lines = [];
+				foreach ( findTemplatePortConflicts($storedTemplate, $portsInUse) as $c ) {
+					if ( $c['label'] !== "" )
+						$lines[] = sprintf(tr('<strong>%1$s</strong> port <strong>%2$s</strong>'), $c['label'], $c['port']);
+					else
+						$lines[] = sprintf(tr('port <strong>%1$s</strong>'), $c['port']);
+				}
+				if ( $lines )
+					$portAdjustMessage = json_encode([
+						"title" => tr("Port conflicts found"),
+						"text"  => implode("<br>", $lines)."<br><br>".tr("These ports were not automatically adjusted."),
+					]);
+			}
+		}
 	}
 	/* Installing a container ends any Docker Hub search it was launched from.
 	   Clearing this per-tab flag makes the Apps page reload restore the template
@@ -3174,7 +3274,7 @@ function createXML() {
 	   check in the Apps.page bootstrap). */
 	@unlink(CA_PATHS['dockerSearchActive']);
 	caDropInfoCache();
-	postReturn(["status"=>"ok","cache"=>$cacheVolume ?? ""]);
+	postReturn(["status"=>"ok","cache"=>$cacheVolume ?? "","portAdjustMessage"=>$portAdjustMessage ?? ""]);
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/exec.php
@@ -2964,11 +2964,7 @@ function checkMultiPortConflicts() {
 
 	$conflicting = [];
 	if ( ($GLOBALS['caSettings']['adjustPorts'] ?? "yes") === "yes" ) {
-		$taken = [];
-		foreach (array_merge(getPortsInUse(), getStoppedBridgePorts(getAllInfo())) as $p) {
-			$pi = (int)$p;
-			if ($pi > 0) $taken[$pi] = true;
-		}
+		$taken = caBuildTakenPorts(array_merge(getPortsInUse(), getStoppedBridgePorts(getAllInfo())));
 		foreach ($names as $name) {
 			// update_container resolves these names to my-NAME.xml in templates-user;
 			// match that, with a space->dash fallback for older saved filenames.

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -1998,16 +1998,49 @@ function debug($str) {
 }
 
 /**
- * Bump any host port in a bridge-network template that's already in use to the next free port.
+ * Normalize a port-config Mode (or a docker Ports Type) to a transport protocol.
+ *
+ * Returns "udp" only for an explicit udp, otherwise "tcp". Host-port conflicts
+ * are per protocol, so tcp/8080 and udp/8080 are distinct bindings.
+ *
+ * @param  mixed $mode
+ * @return string  "tcp" or "udp"
+ */
+function caPortProto($mode): string {
+	return strtolower(trim((string)$mode)) === "udp" ? "udp" : "tcp";
+}
+
+/**
+ * Build a lookup of taken host bindings keyed as "port/proto".
+ *
+ * Accepts a list whose entries are already "port/proto" (from getPortsInUse /
+ * getStoppedBridgePorts) or bare port numbers (defaulted to tcp).
+ *
+ * @param  array<int,int|string> $portsInUse
+ * @return array<string,bool>
+ */
+function caBuildTakenPorts(array $portsInUse): array {
+	$taken = [];
+	foreach ($portsInUse as $p) {
+		$p = (string)$p;
+		if ($p === "") continue;
+		if (strpos($p, "/") === false) $p = ((int)$p)."/tcp";
+		$taken[$p] = true;
+	}
+	return $taken;
+}
+
+/**
+ * Bump any host port in a bridge-network template that's already in use to a free port.
  *
  * Edits $template in place. Treats $portsInUse (and any port assigned earlier
- * within this same template) as "taken"; iterates upward until a free port is
- * found or the 16-bit range is exhausted. No-op for non-bridge networks since
- * host ports don't apply there.
+ * within this same template) as "taken", per protocol; searches for a free port
+ * (wrapping past 65535 to 1) or gives up after the full range. No-op for
+ * non-bridge networks since host ports don't apply there.
  *
  * @param  array<string,mixed>     $template     Modified by reference.
- * @param  array<int,int|string>   $portsInUse   Ports already bound on the host.
- * @return array<int,array{from:int,to:int}>  Each host port that was remapped, old -> new.
+ * @param  array<int,int|string>   $portsInUse   Bindings already taken ("port/proto" or bare port).
+ * @return array<int,array{from:int,to:int,label:string}>  Each host port that was remapped, old -> new.
  */
 function adjustTemplatePorts(array &$template, array $portsInUse): array {
 	$changes = [];
@@ -2019,26 +2052,27 @@ function adjustTemplatePorts(array &$template, array $portsInUse): array {
 	}
 	if (!is_array($template['Config'])) return $changes;
 
-	$taken = [];
-	foreach ($portsInUse as $p) {
-		$pi = (int)$p;
-		if ($pi > 0) $taken[$pi] = true;
-	}
+	$taken = caBuildTakenPorts($portsInUse);
 
 	foreach ($template['Config'] as &$config) {
 		if (!is_array($config) || ($config['@attributes']['Type'] ?? null) !== 'Port') continue;
 		$current = (int)($config['value'] ?: ($config['@attributes']['Default'] ?? 0));
 		if ($current <= 0 || $current > 65535) continue;
-		if (!isset($taken[$current])) {
-			$taken[$current] = true;
+		$proto = caPortProto($config['@attributes']['Mode'] ?? "");
+		if (!isset($taken[$current."/".$proto])) {
+			$taken[$current."/".$proto] = true;
 			continue;
 		}
-		$candidate = $current + 1;
-		while ($candidate < 65536 && isset($taken[$candidate])) {
-			$candidate++;
+		// Conflict for this protocol: find the next free host port, wrapping past
+		// 65535 back to 1 so a busy upper range still resolves before giving up.
+		$candidate = $current;
+		$found = false;
+		for ($i = 0; $i < 65535; $i++) {
+			$candidate = ($candidate % 65535) + 1;
+			if (!isset($taken[$candidate."/".$proto])) { $found = true; break; }
 		}
-		if ($candidate >= 65536) continue;
-		$taken[$candidate] = true;
+		if (!$found) continue;
+		$taken[$candidate."/".$proto] = true;
 		$config['value'] = (string)$candidate;
 		// Carry the port's human label so the notice can name what moved. Prefer
 		// the config Description, then its Name, then the container Target.
@@ -2072,17 +2106,14 @@ function findTemplatePortConflicts(array $template, array $portsInUse): array {
 	}
 	if (!is_array($template['Config'])) return $conflicts;
 
-	$taken = [];
-	foreach ($portsInUse as $p) {
-		$pi = (int)$p;
-		if ($pi > 0) $taken[$pi] = true;
-	}
+	$taken = caBuildTakenPorts($portsInUse);
 
 	foreach ($template['Config'] as $config) {
 		if (!is_array($config) || ($config['@attributes']['Type'] ?? null) !== 'Port') continue;
 		$current = (int)($config['value'] ?: ($config['@attributes']['Default'] ?? 0));
 		if ($current <= 0 || $current > 65535) continue;
-		if (!isset($taken[$current])) continue;
+		$proto = caPortProto($config['@attributes']['Mode'] ?? "");
+		if (!isset($taken[$current."/".$proto])) continue;
 		$label = $config['@attributes']['Description']
 			?: ($config['@attributes']['Name'] ?? "")
 			?: ($config['@attributes']['Target'] ?? "");
@@ -2092,13 +2123,13 @@ function findTemplatePortConflicts(array $template, array $portsInUse): array {
 }
 
 /**
- * Return all host ports a bridge template would publish (as ints).
+ * Return all host bindings a bridge template would publish, as "port/proto".
  *
  * Used by the multi-install batch check to reserve an accepted app's ports so
  * later apps in the same batch are tested against it. Empty for non-bridge.
  *
  * @param  array<string,mixed> $template
- * @return array<int,int>
+ * @return array<int,string>
  */
 function getTemplateBridgePorts(array $template): array {
 	$ports = [];
@@ -2113,7 +2144,7 @@ function getTemplateBridgePorts(array $template): array {
 	foreach ($template['Config'] as $config) {
 		if (!is_array($config) || ($config['@attributes']['Type'] ?? null) !== 'Port') continue;
 		$p = (int)($config['value'] ?: ($config['@attributes']['Default'] ?? 0));
-		if ($p > 0 && $p <= 65535) $ports[] = $p;
+		if ($p > 0 && $p <= 65535) $ports[] = $p."/".caPortProto($config['@attributes']['Mode'] ?? "");
 	}
 	return $ports;
 }
@@ -2140,7 +2171,7 @@ function getStoppedBridgePorts(array $allInfo): array {
 		foreach ($containerPorts as $portInfo) {
 			if (!is_array($portInfo)) continue;
 			$pub = $portInfo['PublicPort'] ?? null;
-			if ($pub !== null && $pub !== "") $ports[] = $pub;
+			if ($pub !== null && $pub !== "") $ports[] = ((int)$pub)."/".caPortProto($portInfo['Type'] ?? "");
 		}
 	}
 	return $ports;
@@ -2169,9 +2200,12 @@ function getPortsInUse() {
 
 	foreach ($output as $line) {
 		[$ip, $port] = ca_explode(':', $line);
-		if (!in_array($port,$portsInUse) && (!$bind || in_array(plain($ip),$list)))
-			if ( is_numeric($port) )
-				$portsInUse[] = $port;
+		if ( ! is_numeric($port) ) continue;
+		if ( $bind && ! in_array(plain($ip),$list) ) continue;
+		// lsof LISTEN sockets are TCP; tag the protocol so tcp/udp pairs on the
+		// same host port are treated as distinct bindings downstream.
+		$key = ((int)$port)."/tcp";
+		if ( ! in_array($key,$portsInUse) ) $portsInUse[] = $key;
 	}
 
 	return $portsInUse;

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/include/helpers.php
@@ -1996,36 +1996,6 @@ function debug($str) {
 	}
 	@file_put_contents(CA_PATHS['logging'],date('Y-m-d H:i:s')."  $str\n",FILE_APPEND); //don't run through CA wrapper as this is non-critical
 }
-/**
- * Return a JSON-encoded list of host ports declared in a bridge-network template.
- *
- * Non-bridge networks always return "[]" since host ports don't apply. Each
- * port entry falls back from value -> Default -> Target.
- *
- * @param  array<string,mixed>  $template
- * @return string JSON list of ports.
- */
-function portsUsed($template) {
-
-	if ( ! is_array($template) || ! isset($template['Config']) ) {
-		return json_encode([]);
-	}
-
-	if ( ($template['Network'] ?? "whatever") !== "bridge")
-		return json_encode([]);
-
-	$portsUsed = [];
-	if ( isset($template['Config']['@attributes']) )
-		$template['Config'] = ['@attributes'=>$template['Config']];
-	if ( is_array($template['Config']) ) {
-		foreach ($template['Config'] as $config) {
-			if ( ($config['@attributes']['Type'] ?? null) !== "Port" )
-				continue;
-			$portsUsed[] = $config['value'] ?: $config['@attributes']['Default'] ?: $config['@attributes']['Target'] ?? null;
-		}
-	}
-	return json_encode($portsUsed,JSON_NUMERIC_CHECK);
-}
 
 /**
  * Bump any host port in a bridge-network template that's already in use to the next free port.
@@ -2037,16 +2007,17 @@ function portsUsed($template) {
  *
  * @param  array<string,mixed>     $template     Modified by reference.
  * @param  array<int,int|string>   $portsInUse   Ports already bound on the host.
- * @return void
+ * @return array<int,array{from:int,to:int}>  Each host port that was remapped, old -> new.
  */
-function adjustTemplatePorts(array &$template, array $portsInUse): void {
-	if (!isset($template['Config'])) return;
-	if (($template['Network'] ?? "") !== "bridge") return;
+function adjustTemplatePorts(array &$template, array $portsInUse): array {
+	$changes = [];
+	if (!isset($template['Config'])) return $changes;
+	if (($template['Network'] ?? "") !== "bridge") return $changes;
 
 	if (isset($template['Config']['@attributes'])) {
 		$template['Config'] = ['@attributes' => $template['Config']];
 	}
-	if (!is_array($template['Config'])) return;
+	if (!is_array($template['Config'])) return $changes;
 
 	$taken = [];
 	foreach ($portsInUse as $p) {
@@ -2069,8 +2040,110 @@ function adjustTemplatePorts(array &$template, array $portsInUse): void {
 		if ($candidate >= 65536) continue;
 		$taken[$candidate] = true;
 		$config['value'] = (string)$candidate;
+		// Carry the port's human label so the notice can name what moved. Prefer
+		// the config Description, then its Name, then the container Target.
+		$label = $config['@attributes']['Description']
+			?: ($config['@attributes']['Name'] ?? "")
+			?: ($config['@attributes']['Target'] ?? "");
+		$changes[] = ['from' => $current, 'to' => $candidate, 'label' => (string)$label];
 	}
 	unset($config);
+	return $changes;
+}
+
+/**
+ * Detect (read-only) host ports in a bridge template that are already taken.
+ *
+ * Mirrors adjustTemplatePorts' matching but changes nothing - used on the
+ * reinstall path, where we warn about conflicts but must not rewrite the user's
+ * saved template. No-op for non-bridge networks.
+ *
+ * @param  array<string,mixed>     $template
+ * @param  array<int,int|string>   $portsInUse
+ * @return array<int,array{port:int,label:string}>  Conflicting ports + label.
+ */
+function findTemplatePortConflicts(array $template, array $portsInUse): array {
+	$conflicts = [];
+	if (!isset($template['Config'])) return $conflicts;
+	if (($template['Network'] ?? "") !== "bridge") return $conflicts;
+
+	if (isset($template['Config']['@attributes'])) {
+		$template['Config'] = ['@attributes' => $template['Config']];
+	}
+	if (!is_array($template['Config'])) return $conflicts;
+
+	$taken = [];
+	foreach ($portsInUse as $p) {
+		$pi = (int)$p;
+		if ($pi > 0) $taken[$pi] = true;
+	}
+
+	foreach ($template['Config'] as $config) {
+		if (!is_array($config) || ($config['@attributes']['Type'] ?? null) !== 'Port') continue;
+		$current = (int)($config['value'] ?: ($config['@attributes']['Default'] ?? 0));
+		if ($current <= 0 || $current > 65535) continue;
+		if (!isset($taken[$current])) continue;
+		$label = $config['@attributes']['Description']
+			?: ($config['@attributes']['Name'] ?? "")
+			?: ($config['@attributes']['Target'] ?? "");
+		$conflicts[] = ['port' => $current, 'label' => (string)$label];
+	}
+	return $conflicts;
+}
+
+/**
+ * Return all host ports a bridge template would publish (as ints).
+ *
+ * Used by the multi-install batch check to reserve an accepted app's ports so
+ * later apps in the same batch are tested against it. Empty for non-bridge.
+ *
+ * @param  array<string,mixed> $template
+ * @return array<int,int>
+ */
+function getTemplateBridgePorts(array $template): array {
+	$ports = [];
+	if (!isset($template['Config'])) return $ports;
+	if (($template['Network'] ?? "") !== "bridge") return $ports;
+
+	if (isset($template['Config']['@attributes'])) {
+		$template['Config'] = ['@attributes' => $template['Config']];
+	}
+	if (!is_array($template['Config'])) return $ports;
+
+	foreach ($template['Config'] as $config) {
+		if (!is_array($config) || ($config['@attributes']['Type'] ?? null) !== 'Port') continue;
+		$p = (int)($config['value'] ?: ($config['@attributes']['Default'] ?? 0));
+		if ($p > 0 && $p <= 65535) $ports[] = $p;
+	}
+	return $ports;
+}
+
+/**
+ * Host ports reserved by installed-but-stopped bridge containers.
+ *
+ * getPortsInUse() only sees live listeners (lsof), so a container that's
+ * installed but not currently running won't show up - yet its mapped host port
+ * would collide the moment it starts. Pull those PublicPorts from the docker
+ * info list (getAllInfo()) so port auto-adjust steers clear of them too. Only
+ * bridge-network containers publish host ports.
+ *
+ * @param  array<int,array<string,mixed>> $allInfo  Output of getAllInfo().
+ * @return array<int,string|int>
+ */
+function getStoppedBridgePorts(array $allInfo): array {
+	$ports = [];
+	foreach ($allInfo as $container) {
+		if ($container['Running'] ?? false) continue;
+		if (strtolower((string)($container['NetworkMode'] ?? "")) !== "bridge") continue;
+		$containerPorts = $container['Ports'] ?? [];
+		if (!is_array($containerPorts)) continue;
+		foreach ($containerPorts as $portInfo) {
+			if (!is_array($portInfo)) continue;
+			$pub = $portInfo['PublicPort'] ?? null;
+			if ($pub !== null && $pub !== "") $ports[] = $pub;
+		}
+	}
+	return $ports;
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/clickHandlers.js
@@ -519,21 +519,21 @@ function caInitializeClickHandlers() {
 	});
 	/**
 	 * Click an XML install button: POST `createXML` with the selected
-	 * template type and any pending port-adjust answer, then redirect to
-	 * the AddContainer page on success.
+	 * template type, then redirect to the AddContainer page on success.
 	 */
 	$("body").on("click", ".xmlInstall", function() {
+		swal.close();
+		mySpinner(0);
 		var type = $(this).data("type");
 		var xml = $(this).data("xml");
-		/* displayTags() (Apps.page) sets window.caPendingAdjustPorts based on
-		   the user's Yes/No answer to the port-conflict prompt. Forward that to
-		   createXML so the server can rewrite conflicting host ports. */
-		var adjustPorts = !!window.caPendingAdjustPorts;
-		window.caPendingAdjustPorts = false;
 		/* saveState() is intentionally not called here — by the time this click
 		   handler fires, showSidebarApp() has already taken the snapshot. */
-		post({ action: "createXML", xml: xml, type: type, adjustPorts: adjustPorts }, function(result) {
+		post({ action: "createXML", xml: xml, type: type }, function(result) {
 			if (result.status == "ok") {
+				// Server remapped conflicting host ports — stash the note so the
+				// AddContainer page can surface it once (ca_browser_back_helper.page).
+				if (result.portAdjustMessage)
+					caSessSet("ca_port_adjustments", result.portAdjustMessage);
 				if (type == "second") type = "default";
 				openNewWindow("/Apps/AddContainer?xmlTemplate=" + type + ":" + xml);
 			}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/helpers.js
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/javascript/helpers.js
@@ -180,13 +180,17 @@ var caSpinnerTimer = null;
  * Show the global spinner after a 250ms delay (skipped if the operation
  * completes first).
  */
-function mySpinner() {
+function mySpinner(wait=250) {
 	if (caSpinnerTimer !== null) return;            // a show is already pending
-	if ($("div.spinner").is(":visible")) return;    // already showing
-	caSpinnerTimer = setTimeout(function() {
-		caSpinnerTimer = null;
+	if ($("div.spinner").is(":visible")) return;  
+	if ( wait===0) {	  // Skip the delay
 		$("div.spinner").show();
-	}, 250);
+	} else {
+		caSpinnerTimer = setTimeout(function() {
+			caSpinnerTimer = null;
+			mySpinner(0);
+		}, wait);	
+	}
 }
 
 /**

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin.html
@@ -664,6 +664,13 @@ $(function() {
 
 					<div class='ca_settingCard'>
 						<div class='ca_settingHeader'>
+							<span><?tr("Adjust Ports");?></span>
+							<?=caSettingSwitchInputs('adjustPorts', $caDefaults)?>
+						</div>
+						<div class='ca_settingDescription'><?tr("Automatically adjust conflicting ports during installation.");?></div>
+					</div>
+					<div class='ca_settingCard'>
+						<div class='ca_settingHeader'>
 							<span><?tr("Enable developer mode");?></span>
 							<?=caSettingSwitchInputs('dev', $caDefaults)?>
 						</div>

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/skin_helpers.php
@@ -560,9 +560,9 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 					}
 					if ($GLOBALS['caSettings']['defaultReinstall'] == "true" && !$template['Blacklist'] && $template['ID'] !== false) {
 						if ($template['BranchID'] ?? false) {
-							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second"),"action"=>"displayTags('{$template['ID']}',true,'".$template['PortsUsed']."');"];
+							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second"),"action"=>"displayTags('{$template['ID']}',true);"];
 						} else {
-							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second"),"action"=>"popupInstallXML('".addslashes($template['Path'])."','second','".$template['PortsUsed']."');"];
+							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install second"),"action"=>"popupInstallXML('".addslashes($template['Path'])."','second');"];
 						}
 					}
 					if (is_file($info[$name]['template'])) {
@@ -575,20 +575,36 @@ function caBuildActionsContext(array &$template, array $info, array $dockerUpdat
 					}
 				} elseif (!$template['Blacklist']) {
 					if ($template['InstallPath']) {
-						$userTemplate = readXmlFile($template['InstallPath'],false,false);
 						if (!$template['Blacklist']) {
-							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Reinstall"),"action"=>"popupInstallXML('".addslashes($template['InstallPath'])."','user','".portsUsed($userTemplate)."');"];
+							$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Reinstall"),"action"=>"popupInstallXML('".addslashes($template['InstallPath'])."','user');"];
+							if (($template['ID'] ?? false) !== false) {
+								if ($template['BranchID'] ?? false) {
+									$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install Default"),"action"=>"displayTags('{$template['ID']}',false);"];
+								} else {
+									$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install Default"),"action"=>"popupInstallXML('".addslashes($template['Path'])."','default');"];
+								}
+							}
 							$actionsContext[] = ["divider"=>true];
 						}
 						$actionsContext[] = ["icon"=>"ca_fa-delete","text"=>tr("Remove"),"action"=>"removeApp('{$template['InstallPath']}','{$template['Name']}');"];
 					} else {
 						if (!$template['Blacklist']) {
+							$caPrevTemplate = CA_PATHS['dockerManTemplates']."/my-{$template['Name']}.xml";
+							$caHasPrev = false;
+							if (is_file($caPrevTemplate)) {
+								$caPrevXml = readXmlFile($caPrevTemplate, true);
+								if ($caPrevXml && ($caPrevXml['Repository'] ?? null) == $template['Repository']) {
+									$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Reinstall"),"action"=>"popupInstallXML('".addslashes($caPrevTemplate)."','user');"];
+									$caHasPrev = true;
+								}
+							}
+							$caInstallLabel = $caHasPrev ? tr("Install Default") : tr("Install");
 							if ($template['Compatible'] || $GLOBALS['caSettings']['hideIncompatible'] !== "true") {
 								if (!$template['Deprecated'] || $GLOBALS['caSettings']['hideDeprecated'] !== "true") {
 									if (!isset($template['BranchID'])) {
-										$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install"),"action"=>"popupInstallXML('".addslashes($template['Path'])."','default','".$template['PortsUsed']."');"];
+										$actionsContext[] = ["icon"=>"ca_fa-install","text"=>$caInstallLabel,"action"=>"popupInstallXML('".addslashes($template['Path'])."','default');"];
 									} else {
-										$actionsContext[] = ["icon"=>"ca_fa-install","text"=>tr("Install"),"action"=>"displayTags('{$template['ID']}',false,'".$template['PortsUsed']."');"];
+										$actionsContext[] = ["icon"=>"ca_fa-install","text"=>$caInstallLabel,"action"=>"displayTags('{$template['ID']}',false);"];
 									}
 								}
 							}
@@ -918,9 +934,9 @@ function caProcessDockerTemplate(array $template, array $info, array $dockerUpda
 			if ($GLOBALS['caSettings']['defaultReinstall'] == "true" && ! $template['Blacklist']) {
 				if ($template['ID'] !== false) {
 					if ($template['BranchID'] ?? false) {
-						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second"), "action" => "displayTags('{$template['ID']}',true,'".$template['PortsUsed']."');"];
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second"), "action" => "displayTags('{$template['ID']}',true);"];
 					} else {
-						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second"), "action" => "popupInstallXML('".addslashes($template['Path'])."','second','".$template['PortsUsed']."');"];
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install second"), "action" => "popupInstallXML('".addslashes($template['Path'])."','second');"];
 					}
 				}
 			}
@@ -941,8 +957,14 @@ function caProcessDockerTemplate(array $template, array $info, array $dockerUpda
 			   "Install" actions further down get gated separately by the
 			   Compatible/Deprecated checks the user has configured. */
 			if ($template['InstallPath']) {
-				$userTemplate = readXmlFile($template['InstallPath'], false, false);
-				$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Reinstall"), "action" => "popupInstallXML('".addslashes($template['InstallPath'])."','user','".portsUsed($userTemplate)."');"];
+				$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Reinstall"), "action" => "popupInstallXML('".addslashes($template['InstallPath'])."','user');"];
+				if (($template['ID'] ?? false) !== false) {
+					if ($template['BranchID'] ?? false) {
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install Default"), "action" => "displayTags('{$template['ID']}',false);"];
+					} else {
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install Default"), "action" => "popupInstallXML('".addslashes($template['Path'])."','default');"];
+					}
+				}
 				$actionsContext[] = ["divider" => true];
 				$actionsContext[] = ["icon" => "ca_fa-delete", "text" => tr("Remove"), "action" => "removeApp('{$template['InstallPath']}','{$template['Name']}');"];
 			} else {
@@ -953,17 +975,16 @@ function caProcessDockerTemplate(array $template, array $info, array $dockerUpda
 						$previousTemplatePath = CA_PATHS['dockerManTemplates']."/my-{$template['Name']}.xml";
 						$test = readXmlFile($previousTemplatePath, true);
 						if ($template['Repository'] == $test['Repository']) {
-							$userTemplate = readXmlFile($previousTemplatePath, false, false);
-							$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Reinstall From Previous Apps"), "action" => "popupInstallXML('".addslashes($previousTemplatePath)."','user','".portsUsed($userTemplate)."');"];
+							$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Reinstall From Previous Apps"), "action" => "popupInstallXML('".addslashes($previousTemplatePath)."','user');"];
 							$actionsContext[] = ["divider" => true];
 						}
 					}
 					if ($canFreshInstall) {
-						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install"), "action" => "popupInstallXML('".addslashes($template['Path'])."','default','".$template['PortsUsed']."');"];
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install"), "action" => "popupInstallXML('".addslashes($template['Path'])."','default');"];
 					}
 				} else {
 					if ($canFreshInstall) {
-						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install"), "action" => "displayTags('{$template['ID']}',false,'".$template['PortsUsed']."');"];
+						$actionsContext[] = ["icon" => "ca_fa-install", "text" => tr("Install"), "action" => "displayTags('{$template['ID']}',false);"];
 					}
 				}
 			}

--- a/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
+++ b/source/community.applications/usr/local/emhttp/plugins/community.applications/skins/Narrow/styles/community.applications.css
@@ -442,12 +442,21 @@ body,
 	position: absolute;
 	inset: 0;
 	background-color: var(--mild-background-color);
-	opacity: 0.72;
+	/* Dark mode (--theme-dark-mode 1) -> 0.8; light mode (0) -> 0.9.
+	   calc drops 0.1 off the 0.9 base only when the dark flag is set. */
+	opacity: calc(0.9 - var(--theme-dark-mode, 0) * 0.1);
+}
+/* On hover the card beneath gets --template-hover-background, but the scrim
+   covers it. Tint the scrim to the same hover colour so the underlying card
+   visibly changes colour like a normal card hover (the orange glow already
+   bleeds past the scrim from .ca_holder:hover). */
+.ca_holder:hover .ca_homeMoreScrim {
+	background-color: var(--template-hover-background);
 }
 .ca_homeMoreOverlay .ca_homeMoreText {
 	position: relative;
 	text-align: center;
-	color: var(--brand-orange);
+	color: var(--text-color);
 }
 .ca_homeMoreTitle {
 	font-size: 2rem;


### PR DESCRIPTION
## Summary

Adds server-side host-port conflict handling for container installs, gated on a new **Adjust Ports** setting (default **on**), plus related sidebar actions and an uninstall refresh fix.

### Port conflict handling (new "Adjust Ports" setting, default yes)
- **Fresh / default installs** auto-remap any host port that clashes with a live listener *or* with an installed-but-stopped bridge container, and surface what changed via a notice on the Add Container page.
- **Reinstall** (your saved `/boot` template) is **checked but never rewritten** — it only warns about conflicts.
- **Previous Apps multi-install** skips any app whose host ports would clash, either with the host or with another app accepted earlier in the same batch (first one wins, later one is dropped), and lists which to install individually.

### Sidebar actions
- **Previous Apps**: added **Install Default** (install the current feed template) next to **Reinstall** (your saved template).
- **Browse / search**: for an app you don't currently have installed but have a matching saved template for, the sidebar now shows **Reinstall** alongside **Install Default**.

### Fix
- Uninstalling from the sidebar now calls `refreshDisplay()` so the card's badges update in place, instead of leaving stale "installed" state until a manual refresh.

### Notes
- New `adjustPorts="yes"` in `default.cfg`, added to the settings panel and the `saveSettings()` allowlist.
- Removed the now-dead client-side port-conflict prompt plumbing (`portsUsed()` helper, client `portsInUse` fetch, old prompt code).
- `ca.md5` and the `.plg` files are intentionally not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Adjust Ports”** setting to automatically resolve host port conflicts during installations.
  * Multi-install and reinstall flows now detect port conflicts, warn users, and skip incompatible apps when installing multiple items.
  * Expanded **Previously Installed Apps** with **“Install Default”** and **“Reinstall”** options, including when revisiting an app card.
  * Home-page **“Show More”** overlay now highlights on hover like a standard app card.
* **Bug Fixes**
  * Uninstall now immediately updates app card badge statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->